### PR TITLE
Set up basic workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,33 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      scylladb1:
+        image: scylladb/scylla
+        ports:
+          - 9042:9042
+        options: --health-cmd "cqlsh --debug" --health-interval 5s --health-retries 10
+        volumes:
+          - ${{ github.workspace }}:/workspace
+    steps:
+      - uses: actions/checkout@v2
+      - name: Format check
+        run: cargo fmt --verbose --all -- --check
+      - name: Clippy check
+        run: cargo clippy --verbose -- -D warnings
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        # test threads must be one because else database tests will run in parallel and will result in flaky tests
+        run: cargo test --verbose -- --test-threads=1


### PR DESCRIPTION
Fixes: #1 
There are not many changes in comparison to the workflow in the driver's repository, however I tried to do some changes and they were either not necessary or not possible:

- If we want to `build` without warnings, it's better to add a flag (`-D warnings`) to clippy than trying to make `cargo build` fail in case of warnings.
- Creating a Scylla cluster using Github workflows seems really difficult if not impossible. The Github workflows uses Docker and we can't pass the `seeds` argument when creating a container. I described this issue in more detail on Slack. 

I did not use the `cargo check` step, because it was not mentioned in the issue and as far as I know, it only checks for errors that `cargo build` should fail on anyway.

I also removed flags connected to the `examples` directory, since we don't have it yet.