### PR TITLE
Added support for async operations inside Consumer trait.

### DIFF
--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -13,6 +13,7 @@ chrono = "0.4.19"
 futures = "0.3.17"
 uuid = "0.8.2"
 num_enum = "0.5.4"
+async-trait = "0.1.51"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/scylla-cdc/src/consumer.rs
+++ b/scylla-cdc/src/consumer.rs
@@ -1,9 +1,11 @@
+use async_trait::async_trait;
 use num_enum::TryFromPrimitive;
 use scylla::frame::response::result::{ColumnSpec, CqlValue, Row};
 use std::collections::HashMap;
 
+#[async_trait]
 pub trait Consumer {
-    fn consume_cdc(&mut self, data: CDCRow);
+    async fn consume_cdc(&mut self, data: CDCRow);
 }
 
 pub trait ConsumerFactory {


### PR DESCRIPTION
Fixes #26

I added support for async operations for Consumer trait by introducing a new dependency `async-trait` that is advised as per [source](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/) and making Consumer trait async.