### PR TITLE
Fix clippy complaints about ok_or vs ok_or_else

### DIFF
--- a/scylla-cdc-replicator/src/replicator_consumer.rs
+++ b/scylla-cdc-replicator/src/replicator_consumer.rs
@@ -468,10 +468,10 @@ impl ReplicatorConsumerFactory {
             .get_cluster_data()
             .get_keyspace_info()
             .get(&dest_keyspace_name)
-            .ok_or(anyhow!("Keyspace not found"))?
+            .ok_or_else(|| anyhow!("Keyspace not found"))?
             .tables
             .get(&dest_table_name.to_ascii_lowercase())
-            .ok_or(anyhow!("Table not found"))?
+            .ok_or_else(|| anyhow!("Table not found"))?
             .clone();
 
         Ok(ReplicatorConsumerFactory {


### PR DESCRIPTION
In #10 it turned out that Clippy version used in Github actions has been updated recently and our code no longer passes Clippy checks. This PR addresses this issue.