### PR TITLE
Make cargo clippy analyze the testing code in the GitHub workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Format check
         run: cargo fmt --verbose --all -- --check
       - name: Clippy check
-        run: cargo clippy --verbose -- -D warnings
+        run: cargo clippy --tests --verbose -- -D warnings
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/scylla-cdc-replicator/src/replication_tests.rs
+++ b/scylla-cdc-replicator/src/replication_tests.rs
@@ -111,10 +111,10 @@ mod tests {
             .get_cluster_data()
             .get_keyspace_info()
             .get("test_dst")
-            .ok_or(anyhow!("Keyspace not found"))?
+            .ok_or_else(|| anyhow!("Keyspace not found"))?
             .tables
             .get(&name.to_ascii_lowercase())
-            .ok_or(anyhow!("Table not found"))?
+            .ok_or_else(|| anyhow!("Table not found"))?
             .clone();
 
         let mut consumer = ReplicatorConsumer::new(


### PR DESCRIPTION
# Fixes: #49 
# Description:
This PR changes GitHub workflow to make it analyze with linter the testing code.
