### PR TITLE
Optimize: Attempt to narrow down time window for StreamReaders in CDCLogPrinter

### DIFF
--- a/scylla-cdc-printer/src/printer.rs
+++ b/scylla-cdc-printer/src/printer.rs
@@ -1,3 +1,4 @@
+use std::cmp::max;
 use std::sync::Arc;
 
 use anyhow;
@@ -171,7 +172,7 @@ impl CDCLogPrinterWorker {
                             Arc::new(StreamReader::new(
                                 &self.session,
                                 vec![stream_id.clone()],
-                                self.start_timestamp,
+                                max(self.start_timestamp, generation.timestamp),
                                 self.window_size,
                                 self.safety_interval,
                                 self.sleep_interval,


### PR DESCRIPTION
As I understand there are no CDC rows with cdc$time less than generation they belong to.

So passing to StreamReader a start_timestamp much earlier than the generation given by stream_ids produces multiple unnecessary queries for rows from empty time intervals.

Am I right?