### PR TITLE
Enforce log reader stop after failure of one of the stream readers

### DIFF
--- a/scylla-cdc/src/log_reader.rs
+++ b/scylla-cdc/src/log_reader.rs
@@ -138,12 +138,12 @@ impl CDCReaderWorker {
                         _ => {}
                     }
                 }
-                Some(generation) = generation_receiver.recv(), if next_generation.is_none() => {
+                Some(generation) = generation_receiver.recv(), if next_generation.is_none() && err.is_none() => {
                     next_generation = Some(generation.clone());
                     had_first_generation = true;
                     self.set_upper_timestamp(generation.timestamp).await;
                 }
-                Ok(_) = self.end_timestamp_receiver.changed() => {
+                Ok(_) = self.end_timestamp_receiver.changed(), if err.is_none() => {
                     let timestamp = *self.end_timestamp_receiver.borrow_and_update();
                     self.end_timestamp = timestamp;
                     self.set_upper_timestamp(timestamp).await;


### PR DESCRIPTION
If my understanding is correct new generation can prolong a lifetime of stream readers and continuous calls to `CDCLogReader.stop_at` could even prevent them from stopping.