### PR TITLE
Create a tutorial for the library

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# scylla-cdc-rust
+Scylla-cdc-rust is a library that enables consuming the 
+[Scylla Change Data Capture Log](https://docs.scylladb.com/using-scylla/cdc/)
+in Rust applications. 
+The library automatically and transparently handles errors and topology changes 
+of the underlying Scylla cluster. 
+Thanks to that, the API allows the user to read the CDC log without having to deeply understand 
+the internal structure of CDC.
+
+It is recommended to get familiar with the documentation of CDC first, 
+in order to understand the concept: 
+<https://docs.scylladb.com/using-scylla/cdc/>
+
+The library was written in pure Rust,
+using [Scylla Rust Driver](https://crates.io/crates/scylla)
+and [Tokio](https://crates.io/crates/tokio).
+
+## Getting started
+The best place to get started with the library is the [tutorial](tutorial.md). 
+You can also check the [Scylla University lessons](https://university.scylladb.com/courses/scylla-operations/lessons/change-data-capture-cdc/)
+to learn more about the CDC.
+
+## Examples
+The repository also contains two exemplary applications:
+
+- [Printer](scylla-cdc-printer): prints all changes from CDC log for a selected table.
+- [Replicator](scylla-cdc-replicator): replicates a table from one Scylla cluster to another by reading the CDC log.
+
+## Contact
+Use the GitHub Issues to report bugs or errors. 
+You can also join [ScyllaDB-Users Slack channel](http://slack.scylladb.com/) and discuss on `#cdc` channel.
+
+## Useful links
+
+- [Scylla Rust Driver on GitHub](https://github.com/scylladb/scylla-rust-driver)
+- [Scylla Docs - Change Data Capture (CDC)](https://docs.scylladb.com/using-scylla/cdc/)
+- [Scylla University - Change Data Capture (CDC)](https://university.scylladb.com/courses/scylla-operations/lessons/change-data-capture-cdc/)
+- [ScyllaDB YouTube - Change Data Capture in Scylla](https://www.youtube.com/watch?v=392Nbfrq7Dg)
+- [ScyllaDB Blog - Using Change Data Capture (CDC) in Scylla](https://www.scylladb.com/2020/07/23/using-change-data-capture-cdc-in-scylla/)
+- [scylla-cdc-java - A library for Java](https://github.com/scylladb/scylla-cdc-java)
+- [scylla-cdc-go - A library for Go](https://github.com/scylladb/scylla-cdc-go)
+
+## License
+The library is licensed under Apache License 2.0. 
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+or in the LICENSE.txt file in the repository.

--- a/scylla-cdc/src/cdc_types.rs
+++ b/scylla-cdc/src/cdc_types.rs
@@ -1,9 +1,11 @@
+//! A module containing types related to CDC internal structure.
 use scylla::cql_to_rust::{FromCqlVal, FromCqlValError};
 use scylla::frame::response::result::CqlValue;
 use scylla::frame::value::{Timestamp, Value, ValueTooBig};
 use scylla::FromRow;
 use std::fmt;
 
+/// A struct representing a timestamp of a stream generation.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, FromRow)]
 pub struct GenerationTimestamp {
     pub timestamp: chrono::Duration,
@@ -15,6 +17,7 @@ impl Value for GenerationTimestamp {
     }
 }
 
+/// A struct representing a stream ID.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, FromRow)]
 pub struct StreamID {
     pub(crate) id: Vec<u8>,

--- a/scylla-cdc/src/checkpoints.rs
+++ b/scylla-cdc/src/checkpoints.rs
@@ -1,3 +1,4 @@
+//! A module representing the logic behind saving progress.
 use crate::cdc_types::{GenerationTimestamp, StreamID};
 use anyhow;
 use async_trait::async_trait;
@@ -20,7 +21,7 @@ pub struct Checkpoint {
 }
 
 /// Spawns a new task that periodically saves checkpoints.
-/// Takes vector of tracked by a [`StreamReader`] stream IDs.
+/// Takes vector of tracked by a [`StreamReader`](crate::stream_reader::StreamReader) stream IDs.
 /// Receives value of the last checkpoint via channel.
 /// We are using [`tokio::sync::watch`] channel, because we only need the latest value.
 /// Returns handle to check on this newly created task.
@@ -72,7 +73,7 @@ pub trait CDCCheckpointSaver: Send + Sync {
 
 /// Default implementation for [`CDCCheckpointSaver`] trait.
 /// Saves checkpoints in a special table using ScyllaDB.
-/// Along with checkpoints for each [`StreamReader`], the table contains
+/// Along with checkpoints for each StreamReader, the table contains
 /// a special row used for storing the latest generation.
 pub struct TableBackedCheckpointSaver {
     session: Arc<Session>,

--- a/scylla-cdc/src/consumer.rs
+++ b/scylla-cdc/src/consumer.rs
@@ -49,6 +49,15 @@ impl fmt::Display for OperationType {
     }
 }
 
+const STREAM_ID_NAME: &str = "cdc$stream_id";
+const TIME_NAME: &str = "cdc$time";
+const BATCH_SEQ_NO_NAME: &str = "cdc$batch_seq_no";
+const END_OF_BATCH_NAME: &str = "cdc$end_of_batch";
+const OPERATION_NAME: &str = "cdc$operation";
+const TTL_NAME: &str = "cdc$ttl";
+const IS_DELETED_PREFIX: &str = "cdc$deleted_";
+const ARE_ELEMENTS_DELETED_PREFIX: &str = "cdc$deleted_elements_";
+
 pub struct CDCRowSchema {
     // The usize values are indices of given values in the Row.columns vector.
     pub(crate) stream_id: usize,
@@ -70,15 +79,6 @@ pub struct CDCRowSchema {
     pub(crate) deleted_el_mapping: HashMap<String, usize>,
 }
 
-const STREAM_ID_NAME: &str = "cdc$stream_id";
-const TIME_NAME: &str = "cdc$time";
-const BATCH_SEQ_NO_NAME: &str = "cdc$batch_seq_no";
-const END_OF_BATCH_NAME: &str = "cdc$end_of_batch";
-const OPERATION_NAME: &str = "cdc$operation";
-const TTL_NAME: &str = "cdc$ttl";
-const IS_DELETED_PREFIX: &str = "cdc$deleted_";
-const ARE_ELEMENTS_DELETED_PREFIX: &str = "cdc$deleted_elements_";
-
 impl CDCRowSchema {
     pub fn new(specs: &[ColumnSpec]) -> CDCRowSchema {
         let mut stream_id = 0;
@@ -96,7 +96,6 @@ impl CDCRowSchema {
         // Hashmaps will have indices of data in a new vector without the hardcoded values.
         for (i, spec) in specs.iter().enumerate() {
             match spec.name.as_str() {
-                // spec.name is public since 0.3.0 driver version, it didn't work on 0.2.1.
                 STREAM_ID_NAME => stream_id = i,
                 TIME_NAME => time = i,
                 BATCH_SEQ_NO_NAME => batch_seq_no = i,

--- a/scylla-cdc/src/lib.rs
+++ b/scylla-cdc/src/lib.rs
@@ -1,3 +1,69 @@
+//! Async library for consuming [Scylla Change Data Capture](https://docs.scylladb.com/using-scylla/cdc/) log,
+//! built on top of the [Scylla Rust Driver](https://docs.rs/scylla/latest/scylla/).
+//!
+//! # Why use a library?
+//! The CDC log format is too complicated to be conveniently used in its raw form.
+//! The library enables the user to ignore the intricacies of the log's internal structure and concentrate on the business logic.
+//!
+//! # Other documentation
+//! * [Documentation of Scylla Rust Driver](https://docs.rs/scylla/latest/scylla/)
+//! * [Scylla documentation](https://docs.scylladb.com)
+//! * [Cassandra® documentation](https://cassandra.apache.org/doc/latest/)
+//! * [CDC documentation](https://docs.scylladb.com/using-scylla/cdc/)
+//!
+//! # Getting started
+//! The following code will start reading the CDC log from now until forever and will print type of every operation read.
+//! To learn in more detail about how to use the library, please refer to the [tutorial](https://github.com/scylladb/scylla-cdc-rust/blob/main/tutorial.md).
+//! ```rust,no_run
+//! use async_trait::async_trait;
+//! use scylla::SessionBuilder;
+//! use scylla_cdc::consumer::*;
+//! use scylla_cdc::log_reader::CDCLogReaderBuilder;
+//! use std::sync::Arc;
+//!
+//! struct TypePrinterConsumer;
+//!
+//! #[async_trait]
+//! impl Consumer for TypePrinterConsumer {
+//!     async fn consume_cdc(&mut self, data: CDCRow<'_>) -> anyhow::Result<()> {
+//!         println!("{}", data.operation);
+//!         Ok(())
+//!     }
+//! }
+//!
+//! struct TypePrinterConsumerFactory;
+//!
+//! #[async_trait]
+//! impl ConsumerFactory for TypePrinterConsumerFactory {
+//!     async fn new_consumer(&self) -> Box<dyn Consumer> {
+//!         Box::new(TypePrinterConsumer)
+//!     }
+//! }
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     let session = Arc::new(
+//!         SessionBuilder::new()
+//!             .known_node("172.17.0.2:9042")
+//!             .build()
+//!             .await?,
+//!     );
+//!
+//!     let factory = Arc::new(TypePrinterConsumerFactory);
+//!
+//!     let (_, handle) = CDCLogReaderBuilder::new()
+//!         .session(session)
+//!         .keyspace("ks")
+//!         .table_name("t")
+//!         .consumer_factory(factory)
+//!         .build()
+//!         .await
+//!         .expect("Creating the log reader failed!");
+//!
+//!     handle.await
+//! }
+//! ```
+
 pub mod cdc_types;
 pub mod checkpoints;
 pub mod consumer;

--- a/scylla-cdc/src/log_reader.rs
+++ b/scylla-cdc/src/log_reader.rs
@@ -1,3 +1,17 @@
+//! A module containing the logic behind reading and consuming the data.
+//!
+//! Only one stream generation is being read at a time,
+//! while data from each stream is being read concurrently by different StreamReaders.
+//!
+//! Every StreamReader reads all CDC rows added in a time window
+//! (not longer than `window_size`), then waiting for amount of time equal to `sleep_interval`
+//! before reading the next window.
+//! Before a newly added row is being read by the reader,
+//! a set amount of time, represented by `safety_interval`, must pass.
+//!
+//! For more information about the stream generations,
+//! please refer to the [Scylla CDC documentation](https://docs.scylladb.com/using-scylla/cdc/cdc-stream-generations/).
+
 use std::cmp::max;
 use std::sync::Arc;
 use std::time;

--- a/scylla-cdc/src/stream_reader.rs
+++ b/scylla-cdc/src/stream_reader.rs
@@ -1,3 +1,5 @@
+//! A module containing the logic responsible for reading data from one stream.
+
 use std::cmp::{max, min};
 use std::sync::Arc;
 use std::time;
@@ -25,6 +27,9 @@ pub struct CDCReaderConfig {
     pub pause_between_saves: time::Duration,
 }
 
+/// A component responsible for reading data from one stream.
+/// For the description of the reading algorithm,
+/// please see the documentation of the [`log_reader`](crate::log_reader) module.
 pub struct StreamReader {
     session: Arc<Session>,
     stream_id_vec: Vec<StreamID>,

--- a/tutorial.md
+++ b/tutorial.md
@@ -1,0 +1,288 @@
+# Tutorial for scylla-cdc-rust
+
+This document will guide you through all steps of creating an example 
+application using the library. 
+We're going to create a simpler version of the [printer](scylla-cdc-printer). 
+
+For the purpose of this tutorial, we're going to assume that the table
+we want to observe the logs for was created by using the following query:
+
+```cassandraql
+CREATE TABLE ks.t (pk int, ck int, v int, vs set<int>, PRIMARY KEY (pk, ck)) WITH cdc = {'enabled': 'true'}
+```
+
+## Creating the CDC consumer
+The most important part of using the library is to define a callback that will be executed 
+after reading a CDC log from the database. 
+Such callback is defined by implementing the `Consumer` trait located in `scylla-cdc::consumer`. 
+As for now, we will define a struct with no member variables for this purpose:
+```rust
+struct TutorialConsumer;
+```
+Since the callback will be executed asynchronously, 
+we have to use the [async-trait](https://crates.io/crates/async-trait) crate 
+to implement the `Consumer` trait. 
+We also use the [anyhow](https://crates.io/crates/anyhow) crate for error handling.
+```rust
+use anyhow;
+use async_trait::async_trait;
+use scylla_cdc::consumer::*;
+
+struct TutorialConsumer;
+
+#[async_trait]
+impl Consumer for TutorialConsumer {
+    async fn consume_cdc(&mut self, _data: CDCRow<'_>) -> anyhow::Result<()> {
+        println!("Hello, scylla-cdc!");
+        Ok(())
+    }
+}
+```
+
+We'll cover on how to use the `CDCRow` structure in [Using CDCRow](tutorial.md#using-cdcrow).
+
+The library is going to create one instance of `TutorialConsumer` per CDC stream, so we also need to define
+a `ConsumerFactory` for them:
+```rust
+struct TutorialConsumerFactory;
+
+#[async_trait]
+impl ConsumerFactory for TutorialConsumerFactory {
+    async fn new_consumer(&self) -> Box<dyn Consumer> {
+        Box::new(TutorialConsumer)
+    }
+}
+```
+
+### Adding shared state to the consumer
+Different instances of `Consumer` are being used in separate Tokio tasks. 
+Due to that, the runtime might schedule them on separate threads.
+
+Because of that, a struct implementing the `Consumer` trait should also implement `Send` trait 
+and a struct implementing the `ConsumerFactory` trait should implement `Send` and `Sync` traits.
+Luckily, Rust implements these traits by default if all member variables of a struct implement them.
+
+If the consumers need to share some state, like a reference to an object, 
+they can be wrapped in an [Arc](<https://doc.rust-lang.org/std/sync/struct.Arc.html>).
+
+An example of that might be a `Consumer` that counts rows read by all its instances:
+
+```rust
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct CountingConsumer {
+    counter: Arc<AtomicUsize>
+}
+
+#[async_trait]
+impl Consumer for CountingConsumer {
+    async fn consume_cdc(&mut self, _: CDCRow<'_>) -> anyhow::Result<()> {
+        let curr = self.counter.fetch_add(1, Ordering::SeqCst);
+        println!("Row no.{}", curr + 1);
+        Ok(())
+    }
+}
+```
+
+__Note__: in general, keeping a mutable state in the `Consumer` is not recommended, 
+since it requires synchronization (i.e. a mutex or an atomic like `AtomicUsize`),
+which reduces the speedup granted by Tokio by running the `Consumer` logic on multiple cores.
+
+## Starting the application
+Now we're ready to create our `main` function:
+```rust
+use scylla::SessionBuilder;
+use scylla_cdc::log_reader::CDCLogReaderBuilder;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let session = Arc::new(
+        SessionBuilder::new()
+            .known_node("127.0.0.1:9042")
+            .build()
+            .await?,
+    );
+    let end = chrono::Duration::from_std(
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap(),
+    ).unwrap();
+    let start = end - chrono::Duration::seconds(360);
+    
+    let factory = Arc::new(TutorialConsumerFactory);
+    
+    let (_, handle) = CDCLogReaderBuilder::new()
+        .session(session)
+        .keyspace("ks")
+        .table_name("t")
+        .start_timestamp(start)
+        .end_timestamp(end)
+        .consumer_factory(factory)
+        .build()
+        .await
+        .expect("Creating the log reader failed!");
+
+    handle.await
+}
+```
+As we can see, we have to configure a few things in order to start the log reader:
+
+- First, we have to create a connection to the database, 
+using the `Session` struct from [Scylla Rust Driver](https://crates.io/crates/scylla).
+- Second, specify the keyspace and the table name.
+- Then, we create time bounds for our reader. 
+This step is not compulsory - by default the reader will start reading from now and will continue reading forever.
+In our case, we are going to read all logs added during the last 6 minutes.
+- Next, create the factory. 
+- Now, we can build the log reader.
+
+To see more information about possible configuration of the log reader, see the [documentation](https://docs.rs/scylla-cdc/latest/scylla-cdc/log_reader/index.html).
+Notice, that the `Session` with the database and the factory must be wrapped inside an `Arc`.
+
+After creating the log reader we can `await` the handle it returns 
+so that our application will terminate as soon as the reader finishes.
+
+Now - let's insert some rows into the table. 
+After inserting 3 rows and running the application, you should see the output:
+``` 
+Hello, scylla-cdc!
+Hello, scylla-cdc!
+Hello, scylla-cdc!
+```
+The application printed one line for each CDC log consumed. 
+Now we can proceed and see how to use `CDCRow` struct to process the data.
+
+## Using CDCRow
+Having learned how to run the log reader, we can finally create the main logic of our application.
+We will edit the `consume_cdc` function of the `TutorialConsumer`.
+
+In general, there are four types of columns in CDC. You can access them in the following way:
+
+- CDC metadata columns can be accessed directly as member variables (e.g. `data.stream_id`)
+- values of columns can be accessed by method `get_value` or `take_value`
+- to check if a column was deleted in given operation, use `is_value_deleted`
+- to check which elements were deleted from a collection, use `get_deleted_elements` or `take_deleted_elements`
+
+The data returned is of type [CqlValue](<https://docs.rs/scylla/latest/scylla/frame/response/result/enum.CqlValue.html>)
+from the driver.
+
+For more detailed information about how to interpret these values, 
+check the [CDC documentation](<https://docs.scylladb.com/using-scylla/cdc/cdc-log-table/>).
+
+It is assumed that the user knows the metadata of their table, 
+but they can check if such a column exists in the CDC log, e.g. with method `column_exists`. 
+Refer to the [API documentation](https://docs.rs/scylla-cdc/latest/scylla-cdc/consumer/struct.CDCRow.html) to find an appropriate method.
+
+Back to our application, we will add printing of the data from the table:
+```rust
+async fn consume_cdc(&mut self, mut data: CDCRow<'_>) -> anyhow::Result<()> {
+    println!("_________");
+    println!("Time UUID: {:?}, operation type: {:?}", data.time, data.operation);
+    println!("pk: {}, ck: {}",
+             data.take_value("pk").unwrap().as_int().unwrap(),
+             data.take_value("ck").unwrap().as_int().unwrap());
+    let v = match data.take_value("v") {
+        Some(val) => Some(val.as_int().unwrap()),
+        None => None,
+    };
+    println!("v: {:?}, was deleted: {}",
+             v,
+             data.is_value_deleted("v"));
+    let vs = match data.take_value("vs") {
+        Some(val) => Some(val.into_vec().unwrap()),
+        None => None,
+    };
+    println!("vs: {:?}, was deleted: {}, deleted elements: {:?}",
+             vs,
+             data.is_value_deleted("vs"),
+             data.take_deleted_elements("vs"));
+    println!("_________");
+    Ok(())
+}
+```
+An example of the output:
+``` 
+_________
+Time UUID: 41183ab8-d07c-11ec-d982-2470743b0298, operation type: RowUpdate
+pk: 7, ck: 5
+v: None, was deleted: false
+vs: None, was deleted: false, deleted elements: [Int(6)]
+_________
+_________
+Time UUID: cc07e47a-d07c-11ec-ebc7-e1924abf3e16, operation type: RowUpdate
+pk: 1, ck: 2
+v: Some(8), was deleted: false
+vs: None, was deleted: false, deleted elements: []
+_________
+```
+
+__Note__: CDCRow's lifetime does not allow it to exist after the function terminates.
+If the user wants to save the data for later 
+(e.g. in a consumer that saves all consumed rows in a `vec`)
+they should map the rows to another data structure.
+## Saving progress
+User can periodically save progress while consuming CDC logs and restore it in case of some error.
+This way, the reading can start from last saved checkpoint instead of a timestamp given by the user.
+
+Progress is identified by checkpoints using the `Checkpoint` struct defined as follows:
+```rust
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Checkpoint {
+    pub timestamp: Duration,
+    pub stream_id: StreamID,
+    pub generation: GenerationTimestamp,
+}
+```
+
+Managing saving and restoring is used by implementing `CDCCheckpointSaver` trait defined as follows:
+```rust
+#[async_trait]
+pub trait CDCCheckpointSaver: Send + Sync {
+    async fn save_checkpoint(&self, checkpoint: &Checkpoint) -> anyhow::Result<()>;
+    async fn save_new_generation(&self, generation: &GenerationTimestamp) -> anyhow::Result<()>;
+    async fn load_last_generation(&self) -> anyhow::Result<Option<GenerationTimestamp>>;
+    async fn load_last_checkpoint(
+        &self,
+        stream_id: &StreamID,
+    ) -> anyhow::Result<Option<chrono::Duration>>;
+}
+```
+User can use any way they want to manage checkpoints, for example they can store it in a database or in a file. 
+There is a default implementation that uses ScyllaDB called `TableBackedCheckpointSaver`. 
+Its source code is located in file [checkpoints.rs](scylla-cdc/src/checkpoints.rs) and can serve as an inspiration how to write new checkpoint savers.
+
+Example of usage for `TableBackedCheckpointSaver`:
+```rust
+let user_checkpoint_saver = Arc::new(
+    TableBackedCheckpointSaver::new_with_default_ttl(session, "ks", "checkpoints")
+        .await
+        .unwrap(),
+);
+```
+This example will create checkpoint_saver that will save checkpoints in `keyspace.table_name` table using default TTL of 7 days.
+User can also explicitly provide TTL:
+```rust
+let ttl: i64 = 3600; // TTL of 3600 seconds (one hour).
+let user_checkpoint_saver = Arc::new(
+    TableBackedCheckpointSaver::new(session, "ks", "checkpoints", ttl)
+        .await
+        .unwrap(),
+);
+```
+__Note__: TTL is measured in seconds.
+
+
+To save progress, the user needs to enable it while building the `CDCLogReader` and provide an `Arc` containing an object that implements `CDCCheckpointSaver`. 
+```rust
+let (log_reader, handle) = CDCLogReaderBuilder::new()
+    // ...
+    .should_save_progress(true) // Mark that we want to save progress.
+    .should_load_progress(true) // Mark that we want to start consuming CDC logs from the last saved checkpoint.
+    .pause_between_saves(time::Duration::from_millis(100)) // Save progress each 100 ms. If not specified, a default value of 10 seconds is used.
+    .checkpoint_saver(user_checkpoint_saver) // Use `user_checkpoint_saver to manage checkpoints.
+    .build();
+```
+__Note__: Setting saving/loading progress requires also setting checkpoint_saver to be used.


### PR DESCRIPTION
Fixes #75 
This PR adds a file tutorial.md which contains a short tutorial about how to use our library. It also fills missing documentation, adds the project's license and a readme.