### PR TITLE
Pretty printer

### DIFF
--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -11,7 +11,7 @@ scylla = { git = "https://github.com/scylladb/scylla-rust-driver" }
 tokio = { version = "1.1.0", features = ["rt", "io-util", "net", "time", "macros", "sync"] }
 chrono = "0.4.19"
 futures = "0.3.17"
-uuid = "1.0.0"
+uuid = {version = "1.0.0", features = ["v1"]}
 num_enum = "0.5.4"
 async-trait = "0.1.51"
 tracing = "0.1.31"

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -16,6 +16,7 @@ num_enum = "0.5.4"
 async-trait = "0.1.51"
 tracing = "0.1.31"
 itertools = "0.10.3"
+hex = "0.4.3"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/scylla-cdc/src/cdc_types.rs
+++ b/scylla-cdc/src/cdc_types.rs
@@ -2,6 +2,7 @@ use scylla::cql_to_rust::{FromCqlVal, FromCqlValError};
 use scylla::frame::response::result::CqlValue;
 use scylla::frame::value::{Timestamp, Value, ValueTooBig};
 use scylla::FromRow;
+use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, FromRow)]
 pub struct GenerationTimestamp {
@@ -17,6 +18,13 @@ impl Value for GenerationTimestamp {
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, FromRow)]
 pub struct StreamID {
     pub(crate) id: Vec<u8>,
+}
+
+impl fmt::Display for StreamID {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let encoded_stream_id = hex::encode(self.id.clone());
+        write!(f, "{}", encoded_stream_id)
+    }
 }
 
 impl Value for StreamID {

--- a/scylla-cdc/src/consumer.rs
+++ b/scylla-cdc/src/consumer.rs
@@ -272,6 +272,10 @@ impl CDCRow<'_> {
     pub fn collection_exists(&self, name: &str) -> bool {
         self.schema.deleted_el_mapping.contains_key(name)
     }
+
+    pub fn get_non_cdc_column_names(&self) -> impl Iterator<Item = &str> {
+        self.schema.mapping.keys().map(|column| column.as_str())
+    }
 }
 
 #[cfg(test)]

--- a/scylla-cdc/src/consumer.rs
+++ b/scylla-cdc/src/consumer.rs
@@ -4,6 +4,8 @@ use num_enum::TryFromPrimitive;
 use scylla::frame::response::result::CqlValue::Set;
 use scylla::frame::response::result::{ColumnSpec, CqlValue, Row};
 use std::collections::HashMap;
+use std::fmt;
+use std::fmt::Formatter;
 
 #[async_trait]
 pub trait Consumer: Send {
@@ -28,6 +30,23 @@ pub enum OperationType {
     RowRangeDelInclRight,
     RowRangeDelExclRight,
     PostImage,
+}
+
+impl fmt::Display for OperationType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match *self {
+            OperationType::PreImage => write!(f, "PreImage"),
+            OperationType::RowUpdate => write!(f, "RowUpdate"),
+            OperationType::RowInsert => write!(f, "RowInsert"),
+            OperationType::RowDelete => write!(f, "RowDelete"),
+            OperationType::PartitionDelete => write!(f, "PartitionDelete"),
+            OperationType::RowRangeDelInclLeft => write!(f, "RowRangeDelInclLeft"),
+            OperationType::RowRangeDelExclLeft => write!(f, "RowRangeDelExclLeft"),
+            OperationType::RowRangeDelInclRight => write!(f, "RowRangeDelInclRight"),
+            OperationType::RowRangeDelExclRight => write!(f, "RowRangeDelExclRight"),
+            OperationType::PostImage => write!(f, "PostImage"),
+        }
+    }
 }
 
 pub struct CDCRowSchema {


### PR DESCRIPTION
Fixes #89

This PR adds pretty printing for CDC rows (an example is attached below).

Things to improve: 
* No information about the column schema whether it is frozen, its actual type, or its column kind (regular, primary key, or clustering key).
* The columns appear unordered. I think it would be helpful to have primary keys and clustering keys separated from the regular columns.
* As `Display` trait is not implemented for `CqlType`, I used `{:?}` format specifier to pretty print values, but maybe it would be better to match `CqlType` and print type and value separately.

![image](https://user-images.githubusercontent.com/29541844/170749528-a0230ed8-9512-4104-b30a-96b8d2b5d537.png)
