### PR TITLE
Change modules visibility

### DIFF
--- a/scylla-cdc-printer/Cargo.toml
+++ b/scylla-cdc-printer/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 scylla = { git = "https://github.com/scylladb/scylla-rust-driver" }
-scylla-cdc = { version = "0.1.0", path = "../scylla-cdc" }
+scylla-cdc = { version = "0.1.0", path = "../scylla-cdc", features = ["test"] }
 tokio = { version = "1.1.0", features = ["full"] }
 chrono = "0.4.19"
 futures = "0.3.17"

--- a/scylla-cdc-replicator/Cargo.toml
+++ b/scylla-cdc-replicator/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 # Temporary, until the necessary changes get released.
 scylla = { git = "https://github.com/scylladb/scylla-rust-driver" }
-scylla-cdc = { version = "0.1.0", path = "../scylla-cdc" }
+scylla-cdc = { version = "0.1.0", path = "../scylla-cdc", features = ["test"] }
 tokio = { version = "1.1.0", features = ["full"] }
 async-trait = "0.1.51"
 anyhow = "1.0.48"

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -20,3 +20,8 @@ hex = "0.4.3"
 
 [dev-dependencies]
 hex = "0.4.3"
+
+[features]
+# "test" is a feature used only to share common utility functions for testing in the printer and the replicator.
+# Using this feature outside these two applications is neither necessary nor recommended.
+test = []

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -18,9 +18,6 @@ tracing = "0.1.31"
 itertools = "0.10.3"
 hex = "0.4.3"
 
-[dev-dependencies]
-hex = "0.4.3"
-
 [features]
 # "test" is a feature used only to share common utility functions for testing in the printer and the replicator.
 # Using this feature outside these two applications is neither necessary nor recommended.

--- a/scylla-cdc/src/lib.rs
+++ b/scylla-cdc/src/lib.rs
@@ -4,4 +4,11 @@ mod e2e_tests;
 pub mod log_reader;
 pub mod stream_generations;
 pub mod stream_reader;
+
+// The test module should be visible only if test feature is enabled.
+// Test feature is disabled by default.
+#[cfg(not(feature = "test"))]
+mod test_utilities;
+
+#[cfg(feature = "test")]
 pub mod test_utilities;

--- a/scylla-cdc/src/lib.rs
+++ b/scylla-cdc/src/lib.rs
@@ -1,9 +1,9 @@
-pub mod cdc_types;
+mod cdc_types;
 pub mod consumer;
 mod e2e_tests;
 pub mod log_reader;
-pub mod stream_generations;
-pub mod stream_reader;
+mod stream_generations;
+mod stream_reader;
 
 // The test module should be visible only if test feature is enabled.
 // Test feature is disabled by default.

--- a/scylla-cdc/src/stream_reader.rs
+++ b/scylla-cdc/src/stream_reader.rs
@@ -2,7 +2,6 @@ use std::cmp::{max, min};
 use std::sync::Arc;
 use std::time;
 
-use chrono;
 use futures::StreamExt;
 use scylla::frame::value::Timestamp;
 use scylla::Session;


### PR DESCRIPTION
Most modules present in `scylla-cdc` are not something that should have public visibility. This PR changes that, so that only `consumer` and `log_reader` modules are accessbile from outside the crate.

Because `test_utilities` module is used in the printer and the replicator, it couldn't simply become a hidden module. I used `cfg` and Cargo's `features` to make this module public only if the library is being used with a feature called `test`. 