### PR TITLE
Change return type of the task in `start_saving_checkpoints`.

### DIFF
--- a/scylla-cdc/src/checkpoints.rs
+++ b/scylla-cdc/src/checkpoints.rs
@@ -29,7 +29,7 @@ pub(crate) fn start_saving_checkpoints(
     checkpoint_saver: Arc<dyn CDCCheckpointSaver>,
     receiver: tokio::sync::watch::Receiver<Checkpoint>,
     saving_period: Duration,
-) -> RemoteHandle<anyhow::Result<()>> {
+) -> RemoteHandle<()> {
     let (fut, handle) = async move {
         loop {
             for stream in tracked_streams.iter() {


### PR DESCRIPTION
As mentioned in the [comment](https://github.com/piodul/scylla-cdc-rust/pull/69#discussion_r897924956), the task cannot fail, it shouldn't even return, so it certainly shouldn't return `Result<()>`.

I have changed it to return `()` since Never type is still experimental in Rust. 