### PR TITLE
Bumped the required Clap version to 3.2.

### DIFF
--- a/scylla-cdc-printer/Cargo.toml
+++ b/scylla-cdc-printer/Cargo.toml
@@ -13,7 +13,7 @@ chrono = "0.4.19"
 futures = "0.3.17"
 anyhow = "1.0.51"
 async-trait = "0.1.52"
-clap = { version = "3.1.10", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }
 
 [dev-dependencies]
 scylla-cdc-test-utils = { path = "../scylla-cdc-test-utils" }

--- a/scylla-cdc-replicator/Cargo.toml
+++ b/scylla-cdc-replicator/Cargo.toml
@@ -17,7 +17,7 @@ uuid = {version = "1.0.0", features = ["v1"]}
 futures-util = "0.3.19"
 tracing = "0.1.34"
 chrono = "0.4.19"
-clap = { version = "3.1.10", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }
 
 [dev-dependencies]
 scylla-cdc-test-utils = { path = "../scylla-cdc-test-utils" }


### PR DESCRIPTION
Followup to #101 
Programs couldn't compile if someone had pre-3.2 version of the Clap crate.