### PR TITLE
Fix failing doctest in scylla-cdc/src/lib.rs

### DIFF
--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -22,3 +22,5 @@ hex = "0.4.3"
 hex = "0.4.3"
 rand = "0.8.5"
 scylla-cdc-test-utils = { path = "../scylla-cdc-test-utils" }
+# To compile one of the doc tests, we need rt-multi-thread feature.
+tokio = { version = "1.1.0", features = ["rt", "io-util", "net", "time", "macros", "sync", "rt-multi-thread"] }


### PR DESCRIPTION
One of the doctests was failing, because it did not compile due to a lack of one feature of Tokio. This PR adds this feature in dev-dependencies.