### PR TITLE
Release 0.5.0

### DIFF
--- a/scylla-cdc-printer/Cargo.toml
+++ b/scylla-cdc-printer/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "scylla-cdc-printer"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 scylla = "1.3.1"
-scylla-cdc = { version = "0.4.1", path = "../scylla-cdc" }
+scylla-cdc = { version = "0.5.0", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 chrono = "0.4.19"
 futures = "0.3.17"

--- a/scylla-cdc-replicator/Cargo.toml
+++ b/scylla-cdc-replicator/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "scylla-cdc-replicator"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 scylla = "1.3.1"
-scylla-cdc = { version = "0.4.1", path = "../scylla-cdc" }
+scylla-cdc = { version = "0.5.0", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 async-trait = "0.1.51"
 anyhow = "1.0.48"

--- a/scylla-cdc-test-utils/Cargo.toml
+++ b/scylla-cdc-test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc-test-utils"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 description = "Library for consuming ScyllaDB CDC log for Rust"
 repository = "https://github.com/scylladb/scylla-cdc-rust"


### PR DESCRIPTION
Bump scylla-cdc version to 0.5.0.

Additionally:
- Bump scylla-cdc-printer and scylla-cdc-replicator to 0.1.5, so that their version number shows some change from the previous release;
- Bump scylla-cdc-test-utils to 0.5.0, to match scylla-cdc.