### PR TITLE
Add BrokenConnectionError as a timeout error

### DIFF
--- a/scylla-cdc/src/stream_reader.rs
+++ b/scylla-cdc/src/stream_reader.rs
@@ -329,7 +329,7 @@ impl StreamReader {
                     // especially this CDC is the part of the problem (remember that we may have a few hundred streamIDs - and as a result
                     // create a few hundred requests to the database at a single moment).
                     if is_transient_error(&err) {
-                        self.print_timeout_warning(
+                        self.print_request_failure_warning(
                             &window_begin,
                             &window_end,
                             sleep_after_timeout,
@@ -357,7 +357,7 @@ impl StreamReader {
         Ok(())
     }
 
-    async fn print_timeout_warning(
+    async fn print_request_failure_warning(
         &self,
         window_begin: &value::CqlTimestamp,
         window_end: &value::CqlTimestamp,
@@ -379,7 +379,7 @@ impl StreamReader {
                 page_no = page_no,
                 current_backoff_ms = backoff.as_millis(),
                 driver_error = format!("{:#}", driver_error),
-                "Timeout while fetching CDC rows."
+                "Encountered a transient error while fetching CDC rows."
             );
         }
     }


### PR DESCRIPTION
This most likely fixes DRIVER-7, by extending the list of errors,
that would result in the retry logic being triggered.
This includes any error that I and @wprzytula consider to be transient:

- any kind of error to the network connection to the database
  (BrokenConnectionError / ConnectionPoolError / RequestTimeout)
- any database error that suggest that while request is correct, database cannot handle it now
  (Overloaded / RateLimitReached / Unavailable / ...)
- driver side problems that will likely be solved in the near future
  (UnableToAllocStreamId)

With the assumption that the CDC should not break if there are
some (potentially temporary) connection errors to the database,
we cannot treat those errors in the retry policy, as the rust driver
policy does not allow to wait between retries. For the case of the timeouts,
or broken connections is to have some wait time, to avoid overruling the database.
