### PR TITLE
treewide: replace `chrono::Duration` with `std::time::Duration`

### DIFF
--- a/scylla-cdc-printer/src/printer.rs
+++ b/scylla-cdc-printer/src/printer.rs
@@ -115,6 +115,7 @@ fn print_field(field_name: &str, field_value: &str) -> String {
 mod tests {
     use std::sync::Arc;
     use std::time;
+    use std::time::Duration;
 
     use scylla_cdc::log_reader::CDCLogReaderBuilder;
     use scylla_cdc_test_utils::TEST_TABLE;
@@ -132,7 +133,7 @@ mod tests {
     #[tokio::test]
     async fn test_cdc_log_printer() {
         let start = now();
-        let end = start + chrono::Duration::seconds(2);
+        let end = start + Duration::from_secs(2);
 
         let (shared_session, ks) = prepare_simple_db(false).await.unwrap();
 

--- a/scylla-cdc-replicator/src/main.rs
+++ b/scylla-cdc-replicator/src/main.rs
@@ -50,10 +50,16 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let tables: Vec<_> = args.table.split(',').map(|s| s.to_string()).collect();
     assert!(!tables.is_empty(), "no tables were provided");
-    let start_timestamp = chrono::Duration::milliseconds(match args.start_datetime {
-        Some(s) => chrono::DateTime::parse_from_rfc3339(&s)?.timestamp_millis(),
-        None => chrono::Local::now().timestamp_millis(),
-    });
+    let start_timestamp = match args.start_datetime {
+        Some(s) => Duration::from_millis(
+            u64::try_from(chrono::DateTime::parse_from_rfc3339(&s)?.timestamp_millis()).map_err(
+                |_| anyhow::anyhow!("start datetime must be on or after the Unix epoch"),
+            )?,
+        ),
+        None => std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time is before Unix epoch"),
+    };
     let sleep_interval = Duration::from_secs_f64(args.sleep_interval);
     let mut result = Ok(());
 

--- a/scylla-cdc-replicator/src/replicator.rs
+++ b/scylla-cdc-replicator/src/replicator.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time;
+use std::time::Duration;
 
 use futures_util::future::RemoteHandle;
 use futures_util::stream::FuturesUnordered;
@@ -22,10 +22,10 @@ impl Replicator {
         dest_uri: String,
         dest_keyspace: String,
         dest_tables: Vec<String>,
-        start_timestamp: chrono::Duration,
-        window_size: time::Duration,
-        safety_interval: time::Duration,
-        sleep_interval: time::Duration,
+        start_timestamp: Duration,
+        window_size: Duration,
+        safety_interval: Duration,
+        sleep_interval: Duration,
     ) -> anyhow::Result<(Self, FuturesUnordered<RemoteHandle<anyhow::Result<()>>>)> {
         let source_session = Arc::new(SessionBuilder::new().known_node(source_uri).build().await?);
         let dest_session = Arc::new(SessionBuilder::new().known_node(dest_uri).build().await?);

--- a/scylla-cdc-test-utils/Cargo.toml
+++ b/scylla-cdc-test-utils/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.48"
-chrono = "0.4.19"
 scylla = "1.3.1"

--- a/scylla-cdc-test-utils/src/lib.rs
+++ b/scylla-cdc-test-utils/src/lib.rs
@@ -2,6 +2,8 @@ use std::fmt;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
+use std::time::SystemTime;
 
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
@@ -11,13 +13,15 @@ use scylla::statement::unprepared::Statement;
 pub const TEST_TABLE: &str = "t";
 static UNIQUE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-pub fn now() -> chrono::Duration {
-    chrono::Duration::milliseconds(chrono::Local::now().timestamp_millis())
+pub fn now() -> Duration {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("system time is before Unix epoch")
 }
 
 pub fn unique_name() -> String {
     let cnt = UNIQUE_COUNTER.fetch_add(1, Ordering::SeqCst);
-    let name = format!("test_rust_{}_{}", now().num_seconds(), cnt);
+    let name = format!("test_rust_{}_{}", now().as_secs(), cnt);
     println!("unique_name: {name}");
     name
 }

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -22,7 +22,6 @@ tokio = { version = "1.1.0", features = [
     "macros",
     "sync",
 ] }
-chrono = "0.4.39"
 futures = "0.3.17"
 uuid = { version = "1.0.0", features = ["v1"] }
 num_enum = "0.7.2"

--- a/scylla-cdc/src/cdc_types.rs
+++ b/scylla-cdc/src/cdc_types.rs
@@ -26,7 +26,6 @@ use std::time::UNIX_EPOCH;
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub(crate) struct Timestamp(i64);
 
-#[allow(dead_code)]
 impl Timestamp {
     /// The earliest representable `Timestamp` (milliseconds = `i64::MIN`).
     pub(crate) const MIN: Self = Timestamp(i64::MIN);
@@ -174,12 +173,12 @@ impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for Timestamp {
 /// A struct representing a timestamp of a stream generation.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct GenerationTimestamp {
-    pub(crate) timestamp: chrono::Duration,
+    pub(crate) timestamp: Timestamp,
 }
 
 impl fmt::Display for GenerationTimestamp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.timestamp.num_milliseconds())
+        write!(f, "{}", self.timestamp.as_millis())
     }
 }
 
@@ -189,23 +188,21 @@ impl SerializeValue for GenerationTimestamp {
         typ: &ColumnType,
         writer: CellWriter<'b>,
     ) -> Result<WrittenCellProof<'b>, SerializationError> {
-        CqlTimestamp(self.timestamp.num_milliseconds()).serialize(typ, writer)
+        self.timestamp.serialize(typ, writer)
     }
 }
 
 impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for GenerationTimestamp {
     fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
-        <CqlTimestamp as DeserializeValue<'frame, 'metadata>>::type_check(typ)
+        Timestamp::type_check(typ)
     }
 
     fn deserialize(
         typ: &'metadata ColumnType<'metadata>,
         v: Option<FrameSlice<'frame>>,
     ) -> Result<Self, DeserializationError> {
-        let timestamp = <CqlTimestamp as DeserializeValue<'frame, 'metadata>>::deserialize(typ, v)?;
-
         Ok(GenerationTimestamp {
-            timestamp: chrono::Duration::milliseconds(timestamp.0),
+            timestamp: Timestamp::deserialize(typ, v)?,
         })
     }
 }

--- a/scylla-cdc/src/cdc_types.rs
+++ b/scylla-cdc/src/cdc_types.rs
@@ -1,4 +1,7 @@
 //! A module containing types related to CDC internal structure.
+use scylla::deserialize::DeserializationError;
+use scylla::deserialize::FrameSlice;
+use scylla::deserialize::TypeCheckError;
 use scylla::deserialize::value::DeserializeValue;
 use scylla::frame::response::result::ColumnType;
 use scylla::serialize::SerializationError;
@@ -8,6 +11,165 @@ use scylla::serialize::writers::WrittenCellProof;
 use scylla::statement::Statement;
 use scylla::value::CqlTimestamp;
 use std::fmt;
+use std::ops::Add;
+use std::ops::AddAssign;
+use std::ops::Sub;
+use std::ops::SubAssign;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+/// A point in time represented as milliseconds since the Unix epoch.
+///
+/// Using a distinct type rather than [`Duration`] prevents confusing *instants*
+/// (a fixed point in time) with *intervals* (a length of time).
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub(crate) struct Timestamp(i64);
+
+#[allow(dead_code)]
+impl Timestamp {
+    /// The earliest representable `Timestamp` (milliseconds = `i64::MIN`).
+    pub(crate) const MIN: Self = Timestamp(i64::MIN);
+    /// The latest representable `Timestamp` (milliseconds = `i64::MAX`).
+    pub(crate) const MAX: Self = Timestamp(i64::MAX);
+
+    /// Returns the current wall-clock time as a `Timestamp`.
+    ///
+    /// The returned value holds the number of milliseconds since the Unix epoch
+    /// (1970-01-01 00:00:00 UTC).
+    ///
+    /// This is implemented in terms of [`SystemTime::now`] and is therefore
+    /// **not monotonic**. Because of OS/NTP clock adjustments, a later call to
+    /// `now()` can return a smaller value than an earlier call. Do not use
+    /// `now()` to measure elapsed time; use [`std::time::Instant`] for that
+    /// purpose instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the system clock is so far removed from the Unix epoch
+    /// (in either direction) that it cannot be represented as `i64` milliseconds.
+    pub(crate) fn now() -> Self {
+        match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(d) => Self(
+                i64::try_from(d.as_millis())
+                    .expect("system clock is too far past the Unix epoch to fit in a Timestamp"),
+            ),
+            Err(e) => {
+                let ms = i64::try_from(e.duration().as_millis())
+                    .expect("system clock is too far before the Unix epoch to fit in a Timestamp");
+                // `ms` is the result of converting a `u128` (always non-negative) into `i64`,
+                // so it is in the range [0, i64::MAX]. Negating it therefore cannot overflow.
+                Self(-ms)
+            }
+        }
+    }
+
+    /// Converts a [`Duration`] since the Unix epoch to a `Timestamp`.
+    /// Saturates to [`Timestamp::MAX`] if the duration exceeds `i64::MAX` milliseconds.
+    pub(crate) fn from_duration_since_epoch(d: Duration) -> Self {
+        Timestamp(i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+    }
+
+    /// Returns the timestamp as a [`Duration`] since the Unix epoch.
+    /// Negative values (pre-epoch) are clamped to [`Duration::ZERO`].
+    pub(crate) fn to_duration_since_epoch(self) -> Duration {
+        Duration::from_millis(self.0.max(0) as u64)
+    }
+
+    /// Constructs a `Timestamp` directly from a raw millisecond value.
+    #[cfg(test)]
+    pub(crate) fn from_millis(ms: i64) -> Self {
+        Timestamp(ms)
+    }
+
+    /// Raw millisecond value - identical to the `CqlTimestamp` wire value.
+    pub(crate) fn as_millis(self) -> i64 {
+        self.0
+    }
+
+    /// Returns the amount of time elapsed from `earlier` to `self`.
+    ///
+    /// Mirrors [`std::time::Instant::checked_duration_since`]. Returns `None`
+    /// if `earlier` is actually later than `self`, instead of silently
+    /// saturating at zero, since it is easy to swap the operands by mistake.
+    pub(crate) fn checked_duration_since(self, earlier: Timestamp) -> Option<Duration> {
+        if self.0 < earlier.0 {
+            return None;
+        }
+        // The ordering check above guarantees `self.0 >= earlier.0`,
+        // so `abs_diff` gives the correct non-negative `u64` difference even
+        // when it wouldn't fit in `i64` (e.g. MAX - MIN).
+        Some(Duration::from_millis(self.0.abs_diff(earlier.0)))
+    }
+}
+
+impl Add<Duration> for Timestamp {
+    type Output = Timestamp;
+
+    /// # Panics
+    ///
+    /// Panics if the resulting timestamp would overflow `i64` milliseconds.
+    fn add(self, rhs: Duration) -> Timestamp {
+        let rhs_ms = i128::try_from(rhs.as_millis()).unwrap_or(i128::MAX);
+        let result = i128::from(self.0) + rhs_ms;
+        Timestamp(i64::try_from(result).expect("overflow when adding Duration to Timestamp"))
+    }
+}
+
+impl AddAssign<Duration> for Timestamp {
+    /// # Panics
+    ///
+    /// Panics if the resulting timestamp would overflow `i64` milliseconds.
+    fn add_assign(&mut self, rhs: Duration) {
+        *self = *self + rhs;
+    }
+}
+
+impl Sub<Duration> for Timestamp {
+    type Output = Timestamp;
+
+    /// # Panics
+    ///
+    /// Panics if the resulting timestamp would overflow `i64` milliseconds.
+    fn sub(self, rhs: Duration) -> Timestamp {
+        let rhs_ms = i128::try_from(rhs.as_millis()).unwrap_or(i128::MAX);
+        let result = i128::from(self.0) - rhs_ms;
+        Timestamp(i64::try_from(result).expect("overflow when subtracting Duration from Timestamp"))
+    }
+}
+
+impl SubAssign<Duration> for Timestamp {
+    /// # Panics
+    ///
+    /// Panics if the resulting timestamp would overflow `i64` milliseconds.
+    fn sub_assign(&mut self, rhs: Duration) {
+        *self = *self - rhs;
+    }
+}
+
+impl SerializeValue for Timestamp {
+    fn serialize<'b>(
+        &self,
+        typ: &ColumnType,
+        writer: CellWriter<'b>,
+    ) -> Result<WrittenCellProof<'b>, SerializationError> {
+        CqlTimestamp(self.0).serialize(typ, writer)
+    }
+}
+
+impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for Timestamp {
+    fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
+        <CqlTimestamp as DeserializeValue<'frame, 'metadata>>::type_check(typ)
+    }
+
+    fn deserialize(
+        typ: &'metadata ColumnType<'metadata>,
+        v: Option<FrameSlice<'frame>>,
+    ) -> Result<Self, DeserializationError> {
+        let ts = <CqlTimestamp as DeserializeValue<'frame, 'metadata>>::deserialize(typ, v)?;
+        Ok(Timestamp(ts.0))
+    }
+}
 
 /// A struct representing a timestamp of a stream generation.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -32,14 +194,14 @@ impl SerializeValue for GenerationTimestamp {
 }
 
 impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for GenerationTimestamp {
-    fn type_check(typ: &ColumnType) -> Result<(), scylla::deserialize::TypeCheckError> {
+    fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
         <CqlTimestamp as DeserializeValue<'frame, 'metadata>>::type_check(typ)
     }
 
     fn deserialize(
         typ: &'metadata ColumnType<'metadata>,
-        v: Option<scylla::deserialize::FrameSlice<'frame>>,
-    ) -> Result<Self, scylla::deserialize::DeserializationError> {
+        v: Option<FrameSlice<'frame>>,
+    ) -> Result<Self, DeserializationError> {
         let timestamp = <CqlTimestamp as DeserializeValue<'frame, 'metadata>>::deserialize(typ, v)?;
 
         Ok(GenerationTimestamp {
@@ -72,14 +234,14 @@ impl SerializeValue for StreamID {
 }
 
 impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for StreamID {
-    fn type_check(typ: &ColumnType) -> Result<(), scylla::deserialize::TypeCheckError> {
+    fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
         <Vec<u8> as DeserializeValue<'frame, 'metadata>>::type_check(typ)
     }
 
     fn deserialize(
         typ: &'metadata ColumnType<'metadata>,
-        v: Option<scylla::deserialize::FrameSlice<'frame>>,
-    ) -> Result<Self, scylla::deserialize::DeserializationError> {
+        v: Option<FrameSlice<'frame>>,
+    ) -> Result<Self, DeserializationError> {
         let id = <Vec<u8> as DeserializeValue<'frame, 'metadata>>::deserialize(typ, v)?;
         Ok(StreamID { id })
     }

--- a/scylla-cdc/src/checkpoints.rs
+++ b/scylla-cdc/src/checkpoints.rs
@@ -2,6 +2,7 @@
 use crate::CqlIdentifier;
 use crate::cdc_types::GenerationTimestamp;
 use crate::cdc_types::StreamID;
+use crate::cdc_types::Timestamp;
 use crate::cdc_types::make_idempotent_statement;
 use anyhow;
 use async_trait::async_trait;
@@ -68,10 +69,7 @@ pub trait CDCCheckpointSaver: Send + Sync {
     /// Loads last seen generation from the checkpoint table.
     async fn load_last_generation(&self) -> anyhow::Result<Option<GenerationTimestamp>>;
     /// Loads last seen timestamp for given stream id from the checkpoint table.
-    async fn load_last_checkpoint(
-        &self,
-        stream_id: &StreamID,
-    ) -> anyhow::Result<Option<chrono::Duration>>;
+    async fn load_last_checkpoint(&self, stream_id: &StreamID) -> anyhow::Result<Option<Duration>>;
 }
 
 /// Default implementation for [`CDCCheckpointSaver`] trait.
@@ -162,7 +160,7 @@ fn get_checkpoint_table_schema(table_name: &str) -> String {
 impl CDCCheckpointSaver for TableBackedCheckpointSaver {
     /// Writes new record containing given timestamp to the checkpoint table.
     async fn save_checkpoint(&self, checkpoint: &Checkpoint) -> anyhow::Result<()> {
-        let timestamp = value::CqlTimestamp(checkpoint.timestamp.as_millis() as i64);
+        let timestamp = Timestamp::from_duration_since_epoch(checkpoint.timestamp);
 
         self.session
             .execute_unpaged(
@@ -208,10 +206,7 @@ impl CDCCheckpointSaver for TableBackedCheckpointSaver {
     }
 
     /// Loads last seen timestamp or `None`.
-    async fn load_last_checkpoint(
-        &self,
-        stream_id: &StreamID,
-    ) -> anyhow::Result<Option<chrono::Duration>> {
+    async fn load_last_checkpoint(&self, stream_id: &StreamID) -> anyhow::Result<Option<Duration>> {
         let statement = make_idempotent_statement(format!(
             "SELECT time FROM {}
                     WHERE stream_id = ?
@@ -224,8 +219,8 @@ impl CDCCheckpointSaver for TableBackedCheckpointSaver {
             .query_unpaged(statement, (stream_id,))
             .await?
             .into_rows_result()?
-            .maybe_first_row::<(value::CqlTimestamp,)>()?
-            .map(|t| chrono::Duration::milliseconds(t.0.0)))
+            .maybe_first_row::<(Timestamp,)>()?
+            .map(|t| t.0.to_duration_since_epoch()))
     }
 }
 
@@ -233,6 +228,7 @@ impl CDCCheckpointSaver for TableBackedCheckpointSaver {
 mod tests {
     use crate::cdc_types::GenerationTimestamp;
     use crate::cdc_types::StreamID;
+    use crate::cdc_types::Timestamp;
     use crate::checkpoints::CDCCheckpointSaver;
     use crate::checkpoints::Checkpoint;
     use crate::checkpoints::TableBackedCheckpointSaver;
@@ -240,10 +236,8 @@ mod tests {
     use futures::TryStreamExt;
     use rand::prelude::*;
     use scylla::client::session::Session;
-    use scylla::value;
     use scylla_cdc_test_utils::prepare_db;
     use scylla_cdc_test_utils::unique_name;
-    use std::ops::Add;
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -266,13 +260,13 @@ mod tests {
             .query_iter(format!("SELECT * FROM {table}"), ())
             .await
             .unwrap()
-            .rows_stream::<(StreamID, GenerationTimestamp, value::CqlTimestamp)>()
+            .rows_stream::<(StreamID, GenerationTimestamp, Timestamp)>()
             .unwrap()
             .map(|res| {
                 res.map(|(id, generation, time)| Checkpoint {
                     stream_id: id,
                     generation,
-                    timestamp: Duration::from_millis(time.0 as u64),
+                    timestamp: time.to_duration_since_epoch(),
                 })
             })
             .try_collect::<Vec<_>>()
@@ -291,7 +285,7 @@ mod tests {
                 id: vec![1, 1, 1, 1, 1, 1, 1, 1],
             },
             generation: GenerationTimestamp {
-                timestamp: chrono::Duration::MIN,
+                timestamp: Timestamp::from_duration_since_epoch(Duration::ZERO),
             },
         };
 
@@ -316,8 +310,6 @@ mod tests {
                 .await
                 .unwrap()
                 .unwrap()
-                .to_std()
-                .unwrap()
         )
     }
 
@@ -327,13 +319,13 @@ mod tests {
         let (session, table_name, cp_saver) = setup().await;
 
         let mut generation = GenerationTimestamp {
-            timestamp: chrono::Duration::zero(),
+            timestamp: Timestamp::from_millis(0),
         };
 
-        let delta = chrono::Duration::seconds(10);
+        let delta = Duration::from_secs(10);
 
         for _ in 0..N {
-            generation.timestamp = generation.timestamp.add(delta);
+            generation.timestamp += delta;
             cp_saver.save_new_generation(&generation).await.unwrap();
         }
 
@@ -363,7 +355,7 @@ mod tests {
                 timestamp: Duration::from_secs(random::<u64>() % (100u64 * N_OF_IDS as u64)),
                 stream_id: StreamID { id: vec![0, i] },
                 generation: GenerationTimestamp {
-                    timestamp: chrono::Duration::MAX,
+                    timestamp: Timestamp::MAX,
                 },
             };
 
@@ -380,7 +372,7 @@ mod tests {
                 .await
                 .unwrap()
                 .unwrap();
-            assert_eq!(saved_checkpoint.to_std().unwrap(), cp.timestamp);
+            assert_eq!(saved_checkpoint, cp.timestamp);
         }
     }
 }

--- a/scylla-cdc/src/e2e_tests.rs
+++ b/scylla-cdc/src/e2e_tests.rs
@@ -6,6 +6,7 @@ mod tests {
     use std::hash::Hash;
     use std::sync::Arc;
     use std::time;
+    use std::time::Duration;
 
     use anyhow::Result;
     use anyhow::bail;
@@ -303,7 +304,7 @@ mod tests {
             results.into_iter().all(identity)
         }
 
-        async fn test_cdc(mut self, start: chrono::Duration) -> Result<()> {
+        async fn test_cdc(mut self, start: Duration) -> Result<()> {
             let results = Arc::new(Mutex::new(HashMap::new()));
             let factory = Arc::new(TestConsumerFactory::new(Arc::clone(&results)));
             let end = now();
@@ -312,8 +313,8 @@ mod tests {
                 .session(Arc::clone(&self.session))
                 .keyspace(self.keyspace.as_str())
                 .table_name(self.table_name.as_str())
-                .start_timestamp(start - chrono::Duration::seconds(2))
-                .end_timestamp(end + chrono::Duration::seconds(2))
+                .start_timestamp(start.saturating_sub(Duration::from_secs(2)))
+                .end_timestamp(end.saturating_add(Duration::from_secs(2)))
                 .window_size(time::Duration::from_millis(WINDOW_SIZE))
                 .safety_interval(time::Duration::from_millis(SAFETY_INTERVAL))
                 .sleep_interval(time::Duration::from_millis(SLEEP_INTERVAL))
@@ -439,8 +440,8 @@ mod tests {
     async fn create_reader_with_saving(
         test: &Test,
         factory: &Arc<TestConsumerFactory>,
-        start: chrono::Duration,
-        end: chrono::Duration,
+        start: Duration,
+        end: Duration,
     ) -> RemoteHandle<Result<()>> {
         let default_cp_saver = Arc::new(
             TableBackedCheckpointSaver::new(
@@ -502,13 +503,10 @@ mod tests {
             insert_new_rows_for_saving_test(&mut test, i).await;
             let end = now();
 
-            let handle = create_reader_with_saving(
-                &test,
-                &factory,
-                start,
-                end + chrono::Duration::seconds(1),
-            )
-            .await;
+            let end_with_margin = end
+                .checked_add(Duration::from_secs(1))
+                .unwrap_or(Duration::MAX);
+            let handle = create_reader_with_saving(&test, &factory, start, end_with_margin).await;
 
             handle.await.unwrap();
         }

--- a/scylla-cdc/src/log_reader.rs
+++ b/scylla-cdc/src/log_reader.rs
@@ -15,6 +15,7 @@
 use std::cmp::max;
 use std::sync::Arc;
 use std::time;
+use std::time::Duration;
 use std::time::SystemTime;
 
 use anyhow;
@@ -28,6 +29,7 @@ use tokio::task::JoinHandle;
 use tracing::warn;
 
 use crate::cdc_types::GenerationTimestamp;
+use crate::cdc_types::Timestamp;
 use crate::cdc_types::make_idempotent_statement;
 use crate::checkpoints::CDCCheckpointSaver;
 use crate::consumer::ConsumerFactory;
@@ -46,22 +48,24 @@ pub struct CDCLogReader {
     // Tells the worker to stop
     // Usage of the "watch" channel will make it possible to change the the timestamp later,
     // for example if somebody loses patience and wants to stop now not later
-    end_timestamp: tokio::sync::watch::Sender<chrono::Duration>,
+    end_timestamp: tokio::sync::watch::Sender<Timestamp>,
 }
 
 impl CDCLogReader {
-    fn new(end_timestamp: tokio::sync::watch::Sender<chrono::Duration>) -> Self {
+    fn new(end_timestamp: tokio::sync::watch::Sender<Timestamp>) -> Self {
         CDCLogReader { end_timestamp }
     }
 
     // Tell the worker to set the end timestamp and then stop
-    pub fn stop_at(&mut self, when: chrono::Duration) {
-        let _ = self.end_timestamp.send(when);
+    pub fn stop_at(&mut self, when: Duration) {
+        let _ = self
+            .end_timestamp
+            .send(Timestamp::from_duration_since_epoch(when));
     }
 
     // Tell the worker to stop immediately
     pub fn stop(&mut self) {
-        self.stop_at(chrono::Duration::MIN);
+        let _ = self.end_timestamp.send(Timestamp::MIN);
     }
 
     /// Checks if the given keyspace uses tablets by querying system_schema.scylla_keyspaces.
@@ -92,9 +96,9 @@ struct CDCReaderWorker {
     session: Arc<Session>,
     keyspace: String,
     table_name: String,
-    end_timestamp: chrono::Duration,
+    end_timestamp: Timestamp,
     readers: Vec<Arc<StreamReader>>,
-    end_timestamp_receiver: tokio::sync::watch::Receiver<chrono::Duration>,
+    end_timestamp_receiver: tokio::sync::watch::Receiver<Timestamp>,
     consumer_factory: Arc<dyn ConsumerFactory>,
     config: CDCReaderConfig,
     uses_tablets: bool,
@@ -118,7 +122,10 @@ impl CDCReaderWorker {
         );
         let (mut generation_receiver, _future_handle) = fetcher
             .clone()
-            .fetch_generations_continuously(self.config.lower_timestamp, self.config.sleep_interval)
+            .fetch_generations_continuously(
+                Timestamp::from_duration_since_epoch(self.config.lower_timestamp),
+                self.config.sleep_interval,
+            )
             .await?;
 
         let mut stream_reader_tasks = FuturesUnordered::new();
@@ -194,9 +201,10 @@ impl CDCReaderWorker {
                         .await?;
                 }
 
-                reader_config.lower_timestamp =
-                    max(self.config.lower_timestamp, generation.timestamp);
-
+                reader_config.lower_timestamp = max(
+                    self.config.lower_timestamp,
+                    generation.timestamp.to_duration_since_epoch(),
+                );
                 self.readers = fetcher
                     .fetch_stream_ids(&generation)
                     .await?
@@ -253,15 +261,15 @@ impl CDCReaderWorker {
 
     /// Updates all of the readers with the new upper timestamp.
     /// When the timestamp is reached, the readers will stop after finishing the current request.
-    async fn set_upper_timestamp(&self, new_upper_timestamp: chrono::Duration) {
+    async fn set_upper_timestamp(&self, ts: Timestamp) {
         for reader in self.readers.iter() {
-            reader.set_upper_timestamp(new_upper_timestamp).await;
+            reader.set_upper_timestamp(ts).await;
         }
     }
 
     /// Updates all of the readers with the timestamp in the past, causing them to stop as soon as the current request finishes.
     async fn stop_now(&self) {
-        self.set_upper_timestamp(chrono::Duration::MIN).await;
+        self.set_upper_timestamp(Timestamp::MIN).await;
     }
 }
 
@@ -311,8 +319,8 @@ pub struct CDCLogReaderBuilder {
     session: Option<Arc<Session>>,
     keyspace: Option<String>,
     table_name: Option<String>,
-    start_timestamp: chrono::Duration,
-    end_timestamp: chrono::Duration,
+    start_timestamp: Duration,
+    end_timestamp: Duration,
     window_size: time::Duration,
     safety_interval: time::Duration,
     sleep_interval: time::Duration,
@@ -336,16 +344,13 @@ impl CDCLogReaderBuilder {
     /// * should_save_progress: false,
     /// * pause_between_saves: 10 seconds
     pub fn new() -> CDCLogReaderBuilder {
-        let end_timestamp = chrono::Duration::MAX;
+        let end_timestamp = Duration::MAX;
         let session = None;
         let keyspace = None;
         let table_name = None;
-        let start_timestamp = chrono::Duration::from_std(
-            SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap(),
-        )
-        .unwrap();
+        let start_timestamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("system time is before Unix epoch");
         let window_size = time::Duration::from_millis(DEFAULT_WINDOW_SIZE as u64);
         let safety_interval = time::Duration::from_millis(DEFAULT_SAFETY_INTERVAL as u64);
         let sleep_interval = time::Duration::from_millis(DEFAULT_SLEEP_INTERVAL as u64);
@@ -400,14 +405,14 @@ impl CDCLogReaderBuilder {
 
     /// Set start timestamp from which [`CDCLogReader`] instance will start reading
     /// from the user specified CDC log table.
-    pub fn start_timestamp(mut self, start_timestamp: chrono::Duration) -> Self {
+    pub fn start_timestamp(mut self, start_timestamp: Duration) -> Self {
         self.start_timestamp = start_timestamp;
         self
     }
 
     /// Set end timestamp to stop [`CDCLogReader`] instance reading data
     /// from the user specified CDC log table.
-    pub fn end_timestamp(mut self, end_timestamp: chrono::Duration) -> Self {
+    pub fn end_timestamp(mut self, end_timestamp: Duration) -> Self {
         self.end_timestamp = end_timestamp;
         self
     }
@@ -500,7 +505,7 @@ impl CDCLogReaderBuilder {
             anyhow::anyhow!("failed to create the cdc reader: missing consumer factory")
         })?;
 
-        let end_timestamp = chrono::Duration::MAX;
+        let end_timestamp = Timestamp::from_duration_since_epoch(self.end_timestamp);
         let (end_timestamp_sender, end_timestamp_receiver) =
             tokio::sync::watch::channel(end_timestamp);
         let readers = vec![];
@@ -516,7 +521,10 @@ impl CDCLogReaderBuilder {
                 .load_last_generation()
                 .await?
         {
-            start_timestamp = std::cmp::max(generation.timestamp, start_timestamp);
+            start_timestamp = std::cmp::max(
+                generation.timestamp.to_duration_since_epoch(),
+                start_timestamp,
+            );
         }
 
         let uses_tablets = CDCLogReader::uses_tablets(&session, &keyspace).await?;
@@ -536,7 +544,7 @@ impl CDCLogReaderBuilder {
             session,
             keyspace,
             table_name,
-            end_timestamp: self.end_timestamp,
+            end_timestamp: Timestamp::from_duration_since_epoch(self.end_timestamp),
             readers,
             end_timestamp_receiver,
             consumer_factory,

--- a/scylla-cdc/src/stream_generations.rs
+++ b/scylla-cdc/src/stream_generations.rs
@@ -6,7 +6,6 @@ use futures::stream::StreamExt;
 use scylla::client::session::Session;
 use scylla::statement::Consistency;
 use scylla::statement::unprepared::Statement;
-use scylla::value;
 use std::sync::Arc;
 use std::time;
 use tokio::sync::mpsc;
@@ -15,6 +14,7 @@ use tracing::warn;
 
 use crate::cdc_types::GenerationTimestamp;
 use crate::cdc_types::StreamID;
+use crate::cdc_types::Timestamp;
 use crate::cdc_types::make_idempotent_statement;
 
 /// Component responsible for managing stream generations.
@@ -29,7 +29,7 @@ pub(crate) trait GenerationFetcher: Send + Sync + 'static {
     /// Propagates errors.
     async fn fetch_generation_by_timestamp(
         &self,
-        time: &chrono::Duration,
+        time: &Timestamp,
     ) -> anyhow::Result<Option<GenerationTimestamp>>;
 
     /// Given a generation returns the next generation.
@@ -66,7 +66,7 @@ pub(crate) trait GenerationFetcher: Send + Sync + 'static {
     /// Returns a receiver for new generations and a handle to the background task.
     async fn fetch_generations_continuously(
         self: Arc<Self>,
-        start_timestamp: chrono::Duration,
+        start_timestamp: Timestamp,
         sleep_interval: time::Duration,
     ) -> anyhow::Result<(mpsc::Receiver<GenerationTimestamp>, RemoteHandle<()>)> {
         let (generation_sender, generation_receiver) = mpsc::channel(1);
@@ -204,7 +204,7 @@ impl GenerationFetcher for VnodeGenerationFetcher {
 
     async fn fetch_generation_by_timestamp(
         &self,
-        time: &chrono::Duration,
+        time: &Timestamp,
     ) -> anyhow::Result<Option<GenerationTimestamp>> {
         let query =
             new_distributed_system_query(self.get_generation_by_timestamp_query(), &self.session)
@@ -212,7 +212,7 @@ impl GenerationFetcher for VnodeGenerationFetcher {
 
         let result = self
             .session
-            .query_unpaged(query, (value::CqlTimestamp(time.num_milliseconds()),))
+            .query_unpaged(query, (time,))
             .await?
             .into_rows_result()?
             .maybe_first_row::<(GenerationTimestamp,)>()?
@@ -373,20 +373,13 @@ impl GenerationFetcher for TabletsGenerationFetcher {
 
     async fn fetch_generation_by_timestamp(
         &self,
-        time: &chrono::Duration,
+        time: &Timestamp,
     ) -> anyhow::Result<Option<GenerationTimestamp>> {
         let query = self.get_generation_by_timestamp_query();
 
         let result = self
             .session
-            .query_unpaged(
-                query,
-                (
-                    &self.keyspace_name,
-                    &self.table_name,
-                    value::CqlTimestamp(time.num_milliseconds()),
-                ),
-            )
+            .query_unpaged(query, (&self.keyspace_name, &self.table_name, time))
             .await?
             .into_rows_result()?
             .maybe_first_row::<(GenerationTimestamp,)>()?
@@ -496,6 +489,9 @@ pub fn get_generation_fetcher(
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time;
+
+    use crate::cdc_types::Timestamp;
 
     use rstest::rstest;
     use scylla_cdc_test_utils::prepare_db;
@@ -509,6 +505,7 @@ mod tests {
 
     mod vnode_tests {
         use super::*;
+        use scylla::value;
 
         const TEST_STREAM_TABLE: &str = "cdc_streams_descriptions_v2";
         const TEST_GENERATION_TABLE: &str = "cdc_generation_timestamps";
@@ -611,6 +608,7 @@ mod tests {
 
     mod tablets_tests {
         use super::*;
+        use scylla::value;
 
         const TEST_KEYSPACE: &str = "test_tablets_ks";
         const TEST_TABLE: &str = "test_tablets_table";
@@ -755,10 +753,10 @@ mod tests {
 
         let correct_generations = vec![
             GenerationTimestamp {
-                timestamp: chrono::Duration::milliseconds(GENERATION_NEW_MILLISECONDS),
+                timestamp: Timestamp::from_millis(GENERATION_NEW_MILLISECONDS),
             },
             GenerationTimestamp {
-                timestamp: chrono::Duration::milliseconds(GENERATION_OLD_MILLISECONDS),
+                timestamp: Timestamp::from_millis(GENERATION_OLD_MILLISECONDS),
             },
         ];
 
@@ -798,7 +796,7 @@ mod tests {
         );
 
         for i in 0..timestamps_ms.len() {
-            let timestamp = chrono::Duration::milliseconds(timestamps_ms[i]);
+            let timestamp = Timestamp::from_millis(timestamps_ms[i]);
 
             let generations = fetcher
                 .fetch_generation_by_timestamp(&timestamp)
@@ -808,7 +806,7 @@ mod tests {
             assert_eq!(
                 generations,
                 correct_generations[i].map(|gen_ms| GenerationTimestamp {
-                    timestamp: chrono::Duration::milliseconds(gen_ms)
+                    timestamp: Timestamp::from_millis(gen_ms)
                 }),
             );
         }
@@ -836,7 +834,7 @@ mod tests {
         assert_eq!(
             gen_old_next.unwrap(),
             GenerationTimestamp {
-                timestamp: chrono::Duration::milliseconds(GENERATION_NEW_MILLISECONDS)
+                timestamp: Timestamp::from_millis(GENERATION_NEW_MILLISECONDS)
             }
         );
     }
@@ -849,10 +847,10 @@ mod tests {
         let fetcher = setup(tablets_enabled).await.unwrap().0;
 
         let gen_before_all_others = GenerationTimestamp {
-            timestamp: chrono::Duration::milliseconds(GENERATION_OLD_MILLISECONDS - 1),
+            timestamp: Timestamp::from_millis(GENERATION_OLD_MILLISECONDS - 1),
         };
         let first_gen = GenerationTimestamp {
-            timestamp: chrono::Duration::milliseconds(GENERATION_OLD_MILLISECONDS),
+            timestamp: Timestamp::from_millis(GENERATION_OLD_MILLISECONDS),
         };
         let gen_before_others_next = fetcher
             .fetch_next_generation(&gen_before_all_others)
@@ -869,7 +867,7 @@ mod tests {
         let fetcher = setup(tablets_enabled).await.unwrap().0;
 
         let generation = GenerationTimestamp {
-            timestamp: chrono::Duration::milliseconds(GENERATION_NEW_MILLISECONDS),
+            timestamp: Timestamp::from_millis(GENERATION_NEW_MILLISECONDS),
         };
 
         let stream_ids = fetcher.fetch_stream_ids(&generation).await.unwrap();
@@ -895,18 +893,18 @@ mod tests {
 
         let (mut generation_receiver, _future) = fetcher
             .fetch_generations_continuously(
-                chrono::Duration::milliseconds(GENERATION_OLD_MILLISECONDS - 1),
+                Timestamp::from_millis(GENERATION_OLD_MILLISECONDS - 1),
                 time::Duration::from_millis(100),
             )
             .await
             .unwrap();
 
         let first_gen = GenerationTimestamp {
-            timestamp: chrono::Duration::milliseconds(GENERATION_OLD_MILLISECONDS),
+            timestamp: Timestamp::from_millis(GENERATION_OLD_MILLISECONDS),
         };
 
         let next_gen = GenerationTimestamp {
-            timestamp: chrono::Duration::milliseconds(GENERATION_NEW_MILLISECONDS),
+            timestamp: Timestamp::from_millis(GENERATION_NEW_MILLISECONDS),
         };
 
         let generation = generation_receiver.recv().await.unwrap();
@@ -916,7 +914,7 @@ mod tests {
         assert_eq!(generation, next_gen);
 
         let new_gen = GenerationTimestamp {
-            timestamp: chrono::Duration::milliseconds(GENERATION_NEW_MILLISECONDS + 100),
+            timestamp: Timestamp::from_millis(GENERATION_NEW_MILLISECONDS + 100),
         };
 
         insert_generation_timestamp(&session, tablets_enabled, GENERATION_NEW_MILLISECONDS + 100)

--- a/scylla-cdc/src/stream_reader.rs
+++ b/scylla-cdc/src/stream_reader.rs
@@ -1,9 +1,7 @@
 //! A module containing the logic responsible for reading data from one stream.
 
-use std::cmp::max;
-use std::cmp::min;
+use std::cmp;
 use std::sync::Arc;
-use std::time;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -18,7 +16,6 @@ use scylla::response::PagingState;
 use scylla::response::PagingStateResponse;
 use scylla::response::query_result::QueryResult;
 use scylla::statement::prepared::PreparedStatement;
-use scylla::value;
 use scylla::value::Row;
 use tokio::sync::watch;
 use tokio::time::sleep;
@@ -30,6 +27,7 @@ use tracing::warn;
 use crate::CqlIdentifier;
 use crate::cdc_types::GenerationTimestamp;
 use crate::cdc_types::StreamID;
+use crate::cdc_types::Timestamp;
 use crate::checkpoints::CDCCheckpointSaver;
 use crate::checkpoints::Checkpoint;
 use crate::checkpoints::start_saving_checkpoints;
@@ -42,14 +40,14 @@ const TIMEOUT_FACTOR: u32 = 2;
 
 #[derive(Clone)]
 pub struct CDCReaderConfig {
-    pub lower_timestamp: chrono::Duration,
-    pub window_size: time::Duration,
-    pub safety_interval: time::Duration,
-    pub sleep_interval: time::Duration,
+    pub lower_timestamp: Duration,
+    pub window_size: Duration,
+    pub safety_interval: Duration,
+    pub sleep_interval: Duration,
     pub should_load_progress: bool,
     pub should_save_progress: bool,
     pub checkpoint_saver: Option<Arc<dyn CDCCheckpointSaver>>,
-    pub pause_between_saves: time::Duration,
+    pub pause_between_saves: Duration,
 }
 
 /// A wrapper for `Session` objects used to make mocking the Session possible.
@@ -60,8 +58,8 @@ trait StreamSession: Sync + Send {
         &self,
         statement: &PreparedStatement,
         ids: &[StreamID],
-        window_begin: &value::CqlTimestamp,
-        window_end: &value::CqlTimestamp,
+        window_begin: &Timestamp,
+        window_end: &Timestamp,
         paging_state: PagingState,
     ) -> Result<(QueryResult, PagingStateResponse), ExecutionError>;
 }
@@ -76,8 +74,8 @@ impl StreamSession for Session {
         &self,
         statement: &PreparedStatement,
         ids: &[StreamID],
-        window_begin: &value::CqlTimestamp,
-        window_end: &value::CqlTimestamp,
+        window_begin: &Timestamp,
+        window_end: &Timestamp,
         paging_state: PagingState,
     ) -> Result<(QueryResult, PagingStateResponse), ExecutionError> {
         let (query_result, paging_state_response) = self
@@ -161,7 +159,7 @@ fn is_transient_error(error: &ExecutionError) -> bool {
 pub struct StreamReader {
     session: Arc<dyn StreamSession>,
     stream_id_vec: Vec<StreamID>,
-    upper_timestamp: tokio::sync::Mutex<Option<chrono::Duration>>,
+    upper_timestamp: tokio::sync::Mutex<Option<Timestamp>>,
     config: CDCReaderConfig,
 }
 
@@ -182,9 +180,9 @@ impl StreamReader {
     /// Sets the upper timestamp for the reader.
     /// The [`fetch_cdc`](Self::fetch_cdc) method will stop when this timestamp is reached.
     /// You can update this timestamp even while the [`fetch_cdc`](Self::fetch_cdc) method is running.
-    pub async fn set_upper_timestamp(&self, new_upper_timestamp: chrono::Duration) {
+    pub(crate) async fn set_upper_timestamp(&self, ts: Timestamp) {
         let mut guard = self.upper_timestamp.lock().await;
-        *guard = Some(new_upper_timestamp);
+        *guard = Some(ts);
     }
 
     /// Continuously fetches CDC rows from the specified keyspace.table and passes them to the provided consumer.
@@ -213,12 +211,11 @@ impl StreamReader {
             query_base
         };
 
-        let mut window_begin = self.config.lower_timestamp;
-        // This is nonnegative because `self.config.window_size` is `std::time::Duration`.
-        let window_size = chrono::Duration::from_std(self.config.window_size)?;
-        let safety_interval = chrono::Duration::from_std(self.config.safety_interval)?;
+        let mut window_begin = Timestamp::from_duration_since_epoch(self.config.lower_timestamp);
+        let window_size = self.config.window_size;
+        let safety_interval = self.config.safety_interval;
         let mut checkpoint = Checkpoint {
-            timestamp: window_begin.to_std()?,
+            timestamp: window_begin.to_duration_since_epoch(),
             stream_id: self.stream_id_vec[0].clone(),
             generation: GenerationTimestamp {
                 timestamp: window_begin,
@@ -227,21 +224,22 @@ impl StreamReader {
         let (sender, receiver) = watch::channel(checkpoint.clone());
 
         if self.config.should_load_progress {
-            let mut loaded_timestamp = chrono::Duration::MAX;
+            let mut loaded_timestamp = Timestamp::MAX;
             for stream in &self.stream_id_vec {
-                if let Some(timestamp) = self
+                if let Some(ts) = self
                     .config
                     .checkpoint_saver
                     .as_ref()
                     .unwrap()
                     .load_last_checkpoint(stream)
                     .await?
+                    .map(Timestamp::from_duration_since_epoch)
                 {
-                    loaded_timestamp = min(timestamp, loaded_timestamp);
+                    loaded_timestamp = loaded_timestamp.min(ts);
                 }
             }
-            if loaded_timestamp != chrono::Duration::MAX {
-                window_begin = max(window_begin, loaded_timestamp);
+            if loaded_timestamp != Timestamp::MAX {
+                window_begin = window_begin.max(loaded_timestamp);
             }
         }
 
@@ -255,8 +253,7 @@ impl StreamReader {
             );
         }
 
-        let mut now_timestamp =
-            chrono::Duration::milliseconds(chrono::Local::now().timestamp_millis());
+        let mut now_timestamp = Timestamp::now();
         // Calculate the timestamp until which it is safe to read.
         // We should not read data newer than (now - `safety_interval`),
         // because clock drift and various kinds of latency may influence too recent results.
@@ -270,8 +267,8 @@ impl StreamReader {
                 // If it it's in the future, we issue an error message to make it clear that wrong timestamp was set up as `window_begin`.
                 // Then we wait before starting to read, to satisfy safety interval.
                 error!(
-                    requested_begin_ms_timestamp = window_begin.num_milliseconds(),
-                    current_ms_timestamp = now_timestamp.num_milliseconds(),
+                    requested_begin_ms_timestamp = window_begin.as_millis(),
+                    current_ms_timestamp = now_timestamp.as_millis(),
                     "Provided `CDCReaderConfig::lower_timestamp` that was in the future!\
                     Ensure that the start timestamp is not set in the future or you have a valid checkpoint state.\
                     The CDC readers will wait up to `CDCReaderConfig::safety_interval` before starting to read data."
@@ -284,16 +281,18 @@ impl StreamReader {
                 //
                 // TODO: consider making this log print rate-limited, because there were reports of this being too spammy.
                 debug!(
-                    requested_begin_ms_timestamp = window_begin.num_milliseconds(),
-                    current_ms_timestamp = now_timestamp.num_milliseconds(),
-                    safety_interval_ms = safety_interval.num_milliseconds(),
+                    requested_begin_ms_timestamp = window_begin.as_millis(),
+                    current_ms_timestamp = now_timestamp.as_millis(),
+                    safety_interval_ms = safety_interval.as_millis(),
                     "Provided `CDCReaderConfig::lower_timestamp` that was in a too recent past; it did not include safety interval.\
                     This is expected and minor issue if you provided NOW as the `CDCReaderConfig::lower_timestamp` timestamp.\
                     The CDC readers will wait up to `CDCReaderConfig::safety_interval` before starting to read data."
                 );
             }
             sleep(
-                (window_begin - safe_to_read_until).to_std()?
+                window_begin
+                    .checked_duration_since(safe_to_read_until)
+                    .unwrap_or(Duration::ZERO)
                     // Adding a small buffer to ensure we are past the safety interval, not exactly at its edge.
                     // This is to avoid issues with clock precision.
                     + Duration::from_millis(100),
@@ -302,7 +301,7 @@ impl StreamReader {
         }
 
         loop {
-            now_timestamp = chrono::Duration::milliseconds(chrono::Local::now().timestamp_millis());
+            now_timestamp = Timestamp::now();
             safe_to_read_until = now_timestamp - safety_interval;
 
             // The only possible way for this to happen is when the current `now_timestamp` is less than the previous `now_timestamp`.
@@ -311,13 +310,15 @@ impl StreamReader {
             // In this case, we again wait until the time is safe to read.
             if window_begin > safe_to_read_until {
                 error!(
-                    last_request_end_ms = window_begin.num_milliseconds(),
-                    current_timestamp_ms = now_timestamp.num_milliseconds(),
-                    expected_window_end_ms = safe_to_read_until.num_milliseconds(),
+                    last_request_end_ms = window_begin.as_millis(),
+                    current_timestamp_ms = now_timestamp.as_millis(),
+                    expected_window_end_ms = safe_to_read_until.as_millis(),
                     "The current time broke the monotonicity when creating a CDC request. Ensure the system clock is stable, and is within the safety interval of the database clock."
                 );
                 sleep(
-                    (window_begin - safe_to_read_until).to_std()?
+                    window_begin
+                        .checked_duration_since(safe_to_read_until)
+                        .unwrap_or(Duration::ZERO)
                         // Adding a small buffer to ensure we are past the safety interval, not exactly at its edge.
                         // This is to avoid issues with clock precision.
                         + Duration::from_millis(100),
@@ -327,15 +328,10 @@ impl StreamReader {
             }
 
             // Ask for windows no larger that `window_size`, but also ensure we respect the safety interval.
-            let window_end = std::cmp::min(window_begin + window_size, safe_to_read_until);
+            let window_end = cmp::min(window_begin + window_size, safe_to_read_until);
 
-            self.fetch_and_consume_rows(
-                &query_base,
-                &mut consumer,
-                value::CqlTimestamp(window_begin.num_milliseconds()),
-                value::CqlTimestamp(window_end.num_milliseconds()),
-            )
-            .await?;
+            self.fetch_and_consume_rows(&query_base, &mut consumer, window_begin, window_end)
+                .await?;
 
             if let Some(timestamp_to_stop) = self.upper_timestamp.lock().await.as_ref()
                 && window_end >= *timestamp_to_stop
@@ -344,7 +340,7 @@ impl StreamReader {
             }
 
             window_begin = window_end;
-            checkpoint.timestamp = window_begin.to_std()?;
+            checkpoint.timestamp = window_begin.to_duration_since_epoch();
             sender.send(checkpoint.clone())?;
             sleep(self.config.sleep_interval).await;
         }
@@ -367,8 +363,8 @@ impl StreamReader {
         &self,
         query_base: &PreparedStatement,
         consumer: &mut Box<dyn Consumer>,
-        window_begin: value::CqlTimestamp,
-        window_end: value::CqlTimestamp,
+        window_begin: Timestamp,
+        window_end: Timestamp,
     ) -> anyhow::Result<()> {
         let mut sleep_after_timeout = BASIC_TIMEOUT_SLEEP;
 
@@ -442,8 +438,8 @@ impl StreamReader {
 
     async fn print_request_failure_warning(
         &self,
-        window_begin: &value::CqlTimestamp,
-        window_end: &value::CqlTimestamp,
+        window_begin: &Timestamp,
+        window_end: &Timestamp,
         backoff: Duration,
         page_no: u64,
         driver_error: anyhow::Error,
@@ -457,8 +453,8 @@ impl StreamReader {
 
             warn!(
                 stream_ids = ids_str,
-                window_begin_ms = window_begin.0,
-                window_end_ms = window_end.0,
+                window_begin_ms = window_begin.as_millis(),
+                window_end_ms = window_end.as_millis(),
                 page_no = page_no,
                 current_backoff_ms = backoff.as_millis(),
                 driver_error = format_args!("{:#}", driver_error),
@@ -484,6 +480,7 @@ mod tests {
     use scylla_cdc_test_utils::skip_if_not_supported;
     use std::sync::atomic::AtomicIsize;
     use std::sync::atomic::Ordering::Relaxed;
+    use std::time::SystemTime;
     use tokio::sync::Mutex;
 
     use super::*;
@@ -495,13 +492,18 @@ mod tests {
     const START_TIME_DELAY_IN_SECONDS: i64 = 2;
 
     impl StreamReader {
+        async fn set_upper_ts(&self, d: Duration) {
+            self.set_upper_timestamp(Timestamp::from_duration_since_epoch(d))
+                .await;
+        }
+
         fn test_new(
             session: &Arc<Session>,
             stream_ids: Vec<StreamID>,
-            start_timestamp: chrono::Duration,
-            window_size: time::Duration,
-            safety_interval: time::Duration,
-            sleep_interval: time::Duration,
+            start_timestamp: Duration,
+            window_size: Duration,
+            safety_interval: Duration,
+            sleep_interval: Duration,
         ) -> StreamReader {
             let config = CDCReaderConfig {
                 lower_timestamp: start_timestamp,
@@ -526,10 +528,11 @@ mod tests {
     async fn get_test_stream_reader(session: &Arc<Session>) -> anyhow::Result<StreamReader> {
         let stream_id_vec = get_cdc_stream_id(session).await?;
 
-        let start_timestamp = now() - chrono::Duration::seconds(START_TIME_DELAY_IN_SECONDS);
-        let sleep_interval = time::Duration::from_millis(SLEEP_INTERVAL);
-        let window_size = time::Duration::from_millis(WINDOW_SIZE);
-        let safety_interval = time::Duration::from_millis(SAFETY_INTERVAL);
+        let start_timestamp =
+            now().saturating_sub(Duration::from_secs(START_TIME_DELAY_IN_SECONDS as u64));
+        let sleep_interval = Duration::from_millis(SLEEP_INTERVAL);
+        let window_size = Duration::from_millis(WINDOW_SIZE);
+        let safety_interval = Duration::from_millis(SAFETY_INTERVAL);
 
         let reader = StreamReader::test_new(
             session,
@@ -599,8 +602,8 @@ mod tests {
             &self,
             statement: &PreparedStatement,
             ids: &[StreamID],
-            window_begin: &value::CqlTimestamp,
-            window_end: &value::CqlTimestamp,
+            window_begin: &Timestamp,
+            window_end: &Timestamp,
             paging_state: PagingState,
         ) -> Result<(QueryResult, PagingStateResponse), ExecutionError> {
             if self.counter.fetch_sub(1, Relaxed) >= 0 {
@@ -641,7 +644,7 @@ mod tests {
 
         let cdc_reader = get_test_stream_reader(&shared_session).await.unwrap();
         cdc_reader
-            .set_upper_timestamp(now() + chrono::Duration::seconds(1))
+            .set_upper_ts(now().saturating_add(Duration::from_secs(1)))
             .await;
         let fetched_rows = Arc::new(Mutex::new(vec![]));
         let consumer = Box::new(FetchTestConsumer {
@@ -696,7 +699,7 @@ mod tests {
 
         let cdc_reader = get_test_stream_reader(&shared_session).await.unwrap();
         cdc_reader
-            .set_upper_timestamp(now() + chrono::Duration::seconds(1))
+            .set_upper_ts(now().saturating_add(Duration::from_secs(1)))
             .await;
         let fetched_rows = Arc::new(Mutex::new(vec![]));
         let consumer = Box::new(FetchTestConsumer {
@@ -728,25 +731,32 @@ mod tests {
             "INSERT INTO {} (pk, t, v, s) VALUES ({}, {}, '{}', '{}');",
             TEST_TABLE, 0, 0, "val0", "static0"
         ));
-        let second_ago = chrono::Local::now() - chrono::Duration::seconds(1);
-        let second_ago_timestamp = chrono::Duration::milliseconds(second_ago.timestamp_millis());
-        insert_before_upper_timestamp_query.set_timestamp(second_ago_timestamp.num_microseconds());
+        let second_ago_timestamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("system time is before Unix epoch")
+            .saturating_sub(Duration::from_secs(1));
+        insert_before_upper_timestamp_query.set_timestamp(Some(
+            i64::try_from(second_ago_timestamp.as_micros()).unwrap_or(i64::MAX),
+        ));
         shared_session
             .query_unpaged(insert_before_upper_timestamp_query, ())
             .await
             .unwrap();
 
         let cdc_reader = get_test_stream_reader(&shared_session).await.unwrap();
-        cdc_reader.set_upper_timestamp(now()).await;
+        cdc_reader.set_upper_ts(now()).await;
 
         let mut insert_after_upper_timestamp_query = Statement::new(format!(
             "INSERT INTO {} (pk, t, v, s) VALUES ({}, {}, '{}', '{}');",
             TEST_TABLE, 0, 1, "val1", "static1"
         ));
-        let second_later = chrono::Local::now() + chrono::Duration::seconds(1);
-        let second_later_timestamp =
-            chrono::Duration::milliseconds(second_later.timestamp_millis());
-        insert_after_upper_timestamp_query.set_timestamp(second_later_timestamp.num_microseconds());
+        let second_later_timestamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("system time is before Unix epoch")
+            .saturating_add(Duration::from_secs(1));
+        insert_after_upper_timestamp_query.set_timestamp(Some(
+            i64::try_from(second_later_timestamp.as_micros()).unwrap_or(i64::MAX),
+        ));
         shared_session
             .query_unpaged(insert_after_upper_timestamp_query, ())
             .await
@@ -790,9 +800,9 @@ mod tests {
         cdc_reader.session = Arc::new(mocked_session);
         // Modify default sleep interval so that the test terminates faster
         // (maximal wait time in backoff is equal to sleep_interval).
-        cdc_reader.config.sleep_interval = time::Duration::from_millis(1500);
+        cdc_reader.config.sleep_interval = Duration::from_millis(1500);
         cdc_reader
-            .set_upper_timestamp(now() + chrono::Duration::seconds(1))
+            .set_upper_ts(now().saturating_add(Duration::from_secs(1)))
             .await;
         let fetched_rows = Arc::new(Mutex::new(vec![]));
         let consumer = Box::new(FetchTestConsumer {

--- a/tutorial.md
+++ b/tutorial.md
@@ -102,6 +102,7 @@ Now we're ready to create our `main` function:
 use scylla::SessionBuilder;
 use scylla_cdc::log_reader::CDCLogReaderBuilder;
 use std::sync::Arc;
+use std::time::Duration;
 use std::time::SystemTime;
 
 #[tokio::main]
@@ -112,12 +113,10 @@ async fn main() -> anyhow::Result<()> {
             .build()
             .await?,
     );
-    let end = chrono::Duration::from_std(
-        SystemTime::now()
+    let end = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap(),
-    ).unwrap();
-    let start = end - chrono::Duration::seconds(360);
+            .unwrap();
+    let start = end.saturating_sub(Duration::from_secs(360));
     
     let factory = Arc::new(TutorialConsumerFactory);
     
@@ -266,7 +265,7 @@ pub trait CDCCheckpointSaver: Send + Sync {
     async fn load_last_checkpoint(
         &self,
         stream_id: &StreamID,
-    ) -> anyhow::Result<Option<chrono::Duration>>;
+    ) -> anyhow::Result<Option<Duration>>;
 }
 ```
 


### PR DESCRIPTION
Before this change, parts of the public API used `chrono::Duration`
while others used `std::time::Duration`, with no good reason for the
split. This inconsistency was reported by internal user (see #147).

Replace `chrono::Duration` with `std::time::Duration` throughout the
public API and all internal code, and remove the chrono dependency from
`scylla-cdc` and `scylla-cdc-test-utils`.

`chrono` is still used in a few places to retrieve the current time.

Fixes: #147
Fixes: VECTOR-729