### PR TITLE
Release 0.6.0

### DIFF
--- a/scylla-cdc-printer/Cargo.toml
+++ b/scylla-cdc-printer/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "scylla-cdc-printer"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 scylla = "1.3.1"
-scylla-cdc = { version = "0.5.0", path = "../scylla-cdc" }
+scylla-cdc = { version = "0.6.0", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 chrono = "0.4.19"
 futures = "0.3.17"

--- a/scylla-cdc-replicator/Cargo.toml
+++ b/scylla-cdc-replicator/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "scylla-cdc-replicator"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 scylla = "1.3.1"
-scylla-cdc = { version = "0.5.0", path = "../scylla-cdc" }
+scylla-cdc = { version = "0.6.0", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 async-trait = "0.1.51"
 anyhow = "1.0.48"

--- a/scylla-cdc-test-utils/Cargo.toml
+++ b/scylla-cdc-test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc-test-utils"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 description = "Library for consuming ScyllaDB CDC log for Rust"
 repository = "https://github.com/scylladb/scylla-cdc-rust"


### PR DESCRIPTION
The ScyllaDB team is pleased to announce [scylla-cdc-rust](https://github.com/scylladb/scylla-cdc-rust) v0.6.0, a library that makes it easy to develop Rust applications that consume data from a [Scylla Change Data Capture Log](https://docs.scylladb.com/using-scylla/cdc/).

In this version:

- Improved warning messages in `stream_generation.rs` ([#142](https://github.com/scylladb/scylla-cdc-rust/pull/142)).
- Changed the initial retry interval upon transient request failure in fetching CDC rows: from 10ms to 100ms; the interval remains exponentially increased as part of the exponential backoff logic. (https://github.com/scylladb/scylla-cdc-rust/pull/145/commits/7b25fbeb85e3ea0019b26a94919887d37de3a1f5 in [#145](https://github.com/scylladb/scylla-cdc-rust/pull/145)).
- Made transient request error handling more robust ([#144](https://github.com/scylladb/scylla-cdc-rust/pull/144)).
- Improved handling of time-related issues (misconfiguration, time drifts, etc.) ([#151](https://github.com/scylladb/scylla-cdc-rust/pull/151)).
- Improved code quality and readability ([#148](https://github.com/scylladb/scylla-cdc-rust/pull/148), [#145](https://github.com/scylladb/scylla-cdc-rust/pull/145), [#146](https://github.com/scylladb/scylla-cdc-rust/pull/146)). 

