### PR TITLE
StreamReader: fixes to recent fixes

### DIFF
--- a/scylla-cdc/src/stream_reader.rs
+++ b/scylla-cdc/src/stream_reader.rs
@@ -305,6 +305,7 @@ impl StreamReader {
                         + Duration::from_millis(100),
                 )
                 .await;
+                continue;
             }
 
             // Ask for windows no larger that `window_size`, but also ensure we respect the safety interval.

--- a/scylla-cdc/src/stream_reader.rs
+++ b/scylla-cdc/src/stream_reader.rs
@@ -443,7 +443,7 @@ impl StreamReader {
                 window_end_ms = window_end.0,
                 page_no = page_no,
                 current_backoff_ms = backoff.as_millis(),
-                driver_error = format!("{:#}", driver_error),
+                driver_error = format_args!("{:#}", driver_error),
                 "Encountered a transient error while fetching CDC rows."
             );
         }

--- a/scylla-cdc/src/stream_reader.rs
+++ b/scylla-cdc/src/stream_reader.rs
@@ -17,7 +17,7 @@ use scylla::value;
 use scylla::value::Row;
 use tokio::sync::watch;
 use tokio::time::sleep;
-use tracing::{enabled, error, info, warn};
+use tracing::{debug, enabled, error, warn};
 
 use crate::cdc_types::{GenerationTimestamp, StreamID};
 use crate::checkpoints::{CDCCheckpointSaver, Checkpoint, start_saving_checkpoints};
@@ -265,7 +265,9 @@ impl StreamReader {
                 // This may happen if we start from "now" without any checkpoint.
                 // Then we wait before starting to read, to satisfy safety interval.
                 // This is done also not to require user to think about safety interval when setting start timestamp.
-                info!(
+                //
+                // TODO: consider making this log print rate-limited, because there were reports of this being too spammy.
+                debug!(
                     requested_begin_ms_timestamp = window_begin.num_milliseconds(),
                     current_ms_timestamp = now_timestamp.num_milliseconds(),
                     safety_interval_ms = safety_interval.num_milliseconds(),


### PR DESCRIPTION
1. A bug was introduced in #151 that would result in logic corruption (negative time windows) in case time travel (the system clock going backwards) were experienced. It's fixed here.
2. One log print was introduced at INFO level, but shown to be too spammy. It's downgraded to DEBUG.
3. Bonus: one `format!` is replaced with `format_args!` to elide an allocation.