### PR TITLE
Release 0.6.1

### DIFF
--- a/scylla-cdc-printer/Cargo.toml
+++ b/scylla-cdc-printer/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "scylla-cdc-printer"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 scylla = "1.3.1"
-scylla-cdc = { version = "0.6.0", path = "../scylla-cdc" }
+scylla-cdc = { version = "0.6.1", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 chrono = "0.4.19"
 futures = "0.3.17"

--- a/scylla-cdc-replicator/Cargo.toml
+++ b/scylla-cdc-replicator/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "scylla-cdc-replicator"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 scylla = "1.3.1"
-scylla-cdc = { version = "0.6.0", path = "../scylla-cdc" }
+scylla-cdc = { version = "0.6.1", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 async-trait = "0.1.51"
 anyhow = "1.0.48"

--- a/scylla-cdc-test-utils/Cargo.toml
+++ b/scylla-cdc-test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc-test-utils"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = "Library for consuming ScyllaDB CDC log for Rust"
 repository = "https://github.com/scylladb/scylla-cdc-rust"


### PR DESCRIPTION
The ScyllaDB team is pleased to announce [scylla-cdc-rust](https://github.com/scylladb/scylla-cdc-rust) v0.6.1, a library that makes it easy to develop Rust applications that consume data from a [Scylla Change Data Capture Log](https://docs.scylladb.com/using-scylla/cdc/).

In this version, further changes were done to `stream_reader.rs` after previous fixes done in #151 ([#154](https://github.com/scylladb/scylla-cdc-rust/pull/154)):
1. A bug was introduced in #151 that would result in logic corruption (negative time windows) in case time travel (the system clock going backwards) were experienced. It's fixed here.
2. One log print was introduced at INFO level, but shown to be too spammy. It's downgraded to DEBUG.