### PR TITLE
Introduce CqlIdentifier type to quote keyspace/table names in CQL

### DIFF
--- a/scylla-cdc-replicator/src/replication_tests.rs
+++ b/scylla-cdc-replicator/src/replication_tests.rs
@@ -65,7 +65,7 @@ mod tests {
         let mut consumer = ReplicatorConsumer::new(
             session.clone(),
             ks_dst.to_string(),
-            name.to_string(),
+            name.to_ascii_lowercase(),
             table_schema,
         )
         .await;

--- a/scylla-cdc-replicator/src/replicator_consumer.rs
+++ b/scylla-cdc-replicator/src/replicator_consumer.rs
@@ -14,6 +14,7 @@ use scylla::value::CqlValue::{Map, Set};
 use thiserror::Error;
 use tracing::warn;
 
+use scylla_cdc::CqlIdentifier;
 use scylla_cdc::consumer::*;
 
 #[derive(Error, Debug)]
@@ -81,7 +82,11 @@ impl PrecomputedQueries {
         // Iterator for both: partition keys and clustering keys.
         let keys_iter = get_keys_iter(table_schema);
 
-        let keyspace_table_name = format!("{dest_keyspace_name}.{dest_table_name}");
+        let keyspace_table_name = format!(
+            "{}.{}",
+            CqlIdentifier::new(&dest_keyspace_name),
+            CqlIdentifier::new(&dest_table_name)
+        );
         // Clone, because the iterator is consumed.
         let names = keys_iter.clone().join(",");
         let markers = keys_iter.clone().map(|_| "?").join(",");
@@ -887,12 +892,13 @@ impl ReplicatorConsumerFactory {
         dest_keyspace_name: String,
         dest_table_name: String,
     ) -> anyhow::Result<ReplicatorConsumerFactory> {
+        let dest_table_name = dest_table_name.to_ascii_lowercase();
         let table_schema = session
             .get_cluster_state()
             .get_keyspace(&dest_keyspace_name)
             .ok_or_else(|| anyhow!("Keyspace not found"))?
             .tables
-            .get(&dest_table_name.to_ascii_lowercase())
+            .get(&dest_table_name)
             .ok_or_else(|| anyhow!("Table not found"))?
             .clone();
 

--- a/scylla-cdc/src/checkpoints.rs
+++ b/scylla-cdc/src/checkpoints.rs
@@ -1,4 +1,5 @@
 //! A module representing the logic behind saving progress.
+use crate::CqlIdentifier;
 use crate::cdc_types::{GenerationTimestamp, StreamID, make_idempotent_statement};
 use anyhow;
 use async_trait::async_trait;
@@ -102,7 +103,11 @@ impl TableBackedCheckpointSaver {
         table_name: &str,
         ttl: i64,
     ) -> anyhow::Result<Self> {
-        let checkpoint_table = format!("{keyspace}.{table_name}");
+        let checkpoint_table = format!(
+            "{}.{}",
+            CqlIdentifier::new(keyspace),
+            CqlIdentifier::new(table_name)
+        );
 
         TableBackedCheckpointSaver::create_checkpoints_table(&session, &checkpoint_table).await?;
 

--- a/scylla-cdc/src/cql_identifier.rs
+++ b/scylla-cdc/src/cql_identifier.rs
@@ -1,0 +1,175 @@
+/// A CQL identifier (keyspace name, table name, column name, etc.) that is
+/// always properly quoted when formatted for use in CQL statements.
+///
+/// The inner value stores the name exactly as provided.
+/// The [`Display`](std::fmt::Display) implementation wraps it in double quotes
+/// with embedded double-quote characters escaped by doubling them
+/// (`"` -> `""`), following the CQL grammar.
+///
+/// Names coming from the Scylla driver's cluster metadata are already in
+/// their canonical internal form, so they should be passed through as-is.
+/// The quoting ensures CQL does not case-fold or reject reserved words.
+#[derive(Clone, Debug)]
+pub struct CqlIdentifier {
+    raw: String,
+    quoted: String,
+}
+
+impl CqlIdentifier {
+    /// Creates a new `CqlIdentifier`, preserving the name exactly as given.
+    ///
+    /// The name will be double-quoted when formatted, preventing CQL from case-folding it.
+    /// Pass names in their canonical form (e.g. as read from cluster metadata).
+    pub fn new(name: impl Into<String>) -> Self {
+        let raw = name.into();
+        let quoted = format!(r#""{}""#, raw.replace('"', r#""""#));
+        CqlIdentifier { raw, quoted }
+    }
+
+    /// Returns the raw (unquoted) identifier name.
+    pub fn as_raw(&self) -> &str {
+        &self.raw
+    }
+}
+
+impl PartialEq for CqlIdentifier {
+    fn eq(&self, other: &Self) -> bool {
+        self.raw == other.raw
+    }
+}
+
+impl Eq for CqlIdentifier {}
+
+impl std::hash::Hash for CqlIdentifier {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.raw.hash(state);
+    }
+}
+
+impl std::fmt::Display for CqlIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.quoted)
+    }
+}
+
+impl From<&str> for CqlIdentifier {
+    fn from(s: &str) -> Self {
+        CqlIdentifier::new(s)
+    }
+}
+
+impl From<String> for CqlIdentifier {
+    fn from(s: String) -> Self {
+        CqlIdentifier::new(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CqlIdentifier;
+
+    #[test]
+    fn quotes_lowercase_name() {
+        let id = CqlIdentifier::new("my_table");
+        assert_eq!(id.to_string(), r#""my_table""#);
+    }
+
+    #[test]
+    fn preserves_mixed_case() {
+        let id = CqlIdentifier::new("MyKeyspace");
+        assert_eq!(id.to_string(), r#""MyKeyspace""#);
+    }
+
+    #[test]
+    fn quotes_uppercase_name() {
+        let id = CqlIdentifier::new("ALL_CAPS");
+        assert_eq!(id.to_string(), r#""ALL_CAPS""#);
+    }
+
+    #[test]
+    fn as_raw_returns_original_name() {
+        let id = CqlIdentifier::new("My_Keyspace");
+        assert_eq!(id.as_raw(), "My_Keyspace");
+    }
+
+    #[test]
+    fn from_str_and_from_string_are_equivalent() {
+        let from_str: CqlIdentifier = "SomeName".into();
+        let from_string: CqlIdentifier = String::from("SomeName").into();
+        assert_eq!(from_str, from_string);
+    }
+
+    #[test]
+    fn equal_names_are_equal() {
+        let a = CqlIdentifier::new("ks");
+        let b = CqlIdentifier::new("ks");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn different_names_are_not_equal() {
+        let a = CqlIdentifier::new("ks");
+        let b = CqlIdentifier::new("KS");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn clone_is_equal_to_original() {
+        let id = CqlIdentifier::new("tbl");
+        assert_eq!(id, id.clone());
+    }
+
+    #[test]
+    fn usable_as_hash_map_key() {
+        use std::collections::HashMap;
+        let mut map = HashMap::new();
+        map.insert(CqlIdentifier::new("ks"), 1);
+        assert_eq!(map[&CqlIdentifier::new("ks")], 1);
+    }
+
+    #[test]
+    fn escapes_single_embedded_double_quote() {
+        let id = CqlIdentifier::new(r#"has"quote"#);
+        assert_eq!(id.to_string(), r#""has""quote""#);
+    }
+
+    #[test]
+    fn escapes_multiple_embedded_double_quotes() {
+        let id = CqlIdentifier::new(r#"a"b"c"#);
+        assert_eq!(id.to_string(), r#""a""b""c""#);
+    }
+
+    #[test]
+    fn as_raw_preserves_embedded_quotes() {
+        let id = CqlIdentifier::new(r#"has"quote"#);
+        assert_eq!(id.as_raw(), r#"has"quote"#);
+    }
+
+    #[test]
+    fn empty_name_produces_empty_quoted_identifier() {
+        let id = CqlIdentifier::new("");
+        assert_eq!(id.to_string(), r#""""#);
+        assert_eq!(id.as_raw(), "");
+    }
+
+    #[test]
+    fn whitespace_name_is_preserved() {
+        let id = CqlIdentifier::new("  spaces  ");
+        assert_eq!(id.to_string(), r#""  spaces  ""#);
+        assert_eq!(id.as_raw(), "  spaces  ");
+    }
+
+    #[test]
+    fn special_characters_are_preserved() {
+        let id = CqlIdentifier::new("col$name.with-special!chars");
+        assert_eq!(id.to_string(), r#""col$name.with-special!chars""#);
+        assert_eq!(id.as_raw(), "col$name.with-special!chars");
+    }
+
+    #[test]
+    fn display_composes_into_dotted_keyspace_table() {
+        let ks = CqlIdentifier::new("MyKeyspace");
+        let tbl = CqlIdentifier::new("my_table");
+        assert_eq!(format!("{ks}.{tbl}"), r#""MyKeyspace"."my_table""#);
+    }
+}

--- a/scylla-cdc/src/lib.rs
+++ b/scylla-cdc/src/lib.rs
@@ -67,7 +67,10 @@
 pub mod cdc_types;
 pub mod checkpoints;
 pub mod consumer;
+pub mod cql_identifier;
 mod e2e_tests;
 pub mod log_reader;
 mod stream_generations;
 mod stream_reader;
+
+pub use cql_identifier::CqlIdentifier;

--- a/scylla-cdc/src/stream_reader.rs
+++ b/scylla-cdc/src/stream_reader.rs
@@ -19,6 +19,7 @@ use tokio::sync::watch;
 use tokio::time::sleep;
 use tracing::{debug, enabled, error, warn};
 
+use crate::CqlIdentifier;
 use crate::cdc_types::{GenerationTimestamp, StreamID};
 use crate::checkpoints::{CDCCheckpointSaver, Checkpoint, start_saving_checkpoints};
 use crate::consumer::{CDCRow, CDCRowSchema, Consumer};
@@ -185,8 +186,10 @@ impl StreamReader {
         table_name: String,
         mut consumer: Box<dyn Consumer>,
     ) -> anyhow::Result<()> {
+        let keyspace = CqlIdentifier::new(keyspace);
+        let table_name = CqlIdentifier::new(format!("{table_name}_scylla_cdc_log"));
         let query = format!(
-            "SELECT * FROM {keyspace}.{table_name}_scylla_cdc_log \
+            "SELECT * FROM {keyspace}.{table_name} \
             WHERE \"cdc$stream_id\" in ? \
             AND \"cdc$time\" >= minTimeuuid(?) \
             AND \"cdc$time\" < minTimeuuid(?)  BYPASS CACHE"


### PR DESCRIPTION
Add a CqlIdentifier newtype that wraps identifier names and always produces properly double-quoted output via its Display impl. This prevents CQL from case-folding names, which broke keyspaces with mixed-case names (e.g. those created by Alternator).

All CQL query construction sites now use CqlIdentifier instead of bare string interpolation:
- stream_reader: SELECT from CDC log table
- checkpoints: CREATE TABLE / UPDATE for checkpoint tables
- replicator_consumer: INSERT / DELETE / UPDATE queries (was previously unquoted entirely, which is a correctness bug)

Embedded double-quote characters are escaped by doubling them, following the CQL grammar.

Fixes: [VECTOR-584](https://scylladb.atlassian.net/browse/VECTOR-584)

[VECTOR-584]: https://scylladb.atlassian.net/browse/VECTOR-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ