### PR TITLE
Release 0.6.2

### DIFF
--- a/scylla-cdc-printer/Cargo.toml
+++ b/scylla-cdc-printer/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "scylla-cdc-printer"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 scylla = "1.3.1"
-scylla-cdc = { version = "0.6.1", path = "../scylla-cdc" }
+scylla-cdc = { version = "0.6.2", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 chrono = "0.4.19"
 futures = "0.3.17"

--- a/scylla-cdc-replicator/Cargo.toml
+++ b/scylla-cdc-replicator/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "scylla-cdc-replicator"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 scylla = "1.3.1"
-scylla-cdc = { version = "0.6.1", path = "../scylla-cdc" }
+scylla-cdc = { version = "0.6.2", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 async-trait = "0.1.51"
 anyhow = "1.0.48"

--- a/scylla-cdc-test-utils/Cargo.toml
+++ b/scylla-cdc-test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc-test-utils"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 description = "Library for consuming ScyllaDB CDC log for Rust"
 repository = "https://github.com/scylladb/scylla-cdc-rust"


### PR DESCRIPTION
The ScyllaDB team is pleased to announce [scylla-cdc-rust](https://github.com/scylladb/scylla-cdc-rust) v0.6.2, a library that makes it easy to develop Rust applications that consume data from a [Scylla Change Data Capture Log](https://docs.scylladb.com/using-scylla/cdc/).

**New: CQL identifier quoting (`CqlIdentifier`)**

A new `CqlIdentifier` type has been introduced to properly double-quote keyspace and table names when constructing CQL statements. This fixes a **correctness bug** where mixed-case identifiers (e.g. keyspaces created by Alternator) were silently case-folded by CQL, causing queries to target the wrong keyspace or table.

Bug fixed
* Mixed-case keyspace/table names now work correctly. Previously, names like `MyKeyspace` were interpolated unquoted into CQL strings, causing CQL to normalize them to lowercase (`mykeyspace`). All query construction sites now use `CqlIdentifier`, which wraps names in double quotes and escapes embedded `"` characters by doubling them, following the CQL grammar.

New public API
* `scylla_cdc::CqlIdentifier` — newtype that produces double-quoted CQL identifiers via `Display`, with proper escaping of embedded `"` characters.