### PR TITLE
Release 0.6.3

### DIFF
--- a/scylla-cdc-printer/Cargo.toml
+++ b/scylla-cdc-printer/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "scylla-cdc-printer"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 scylla = "1.3.1"
-scylla-cdc = { version = "0.6.2", path = "../scylla-cdc" }
+scylla-cdc = { version = "0.6.3", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 chrono = "0.4.19"
 futures = "0.3.17"

--- a/scylla-cdc-replicator/Cargo.toml
+++ b/scylla-cdc-replicator/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "scylla-cdc-replicator"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 scylla = "1.3.1"
-scylla-cdc = { version = "0.6.2", path = "../scylla-cdc" }
+scylla-cdc = { version = "0.6.3", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 async-trait = "0.1.51"
 anyhow = "1.0.48"

--- a/scylla-cdc-test-utils/Cargo.toml
+++ b/scylla-cdc-test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc-test-utils"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 description = "Library for consuming ScyllaDB CDC log for Rust"
 repository = "https://github.com/scylladb/scylla-cdc-rust"


### PR DESCRIPTION
The ScyllaDB team is pleased to announce [scylla-cdc-rust](https://github.com/scylladb/scylla-cdc-rust) v0.6.3, a library that makes it easy to develop Rust applications that consume data from a [Scylla Change Data Capture Log](https://docs.scylladb.com/using-scylla/cdc/).

**New: Internal operation types for Alternator**

`OperationType` now recognizes the negative-discriminant operation codes (-3, -4) that Scylla's Alternator uses internally for partition and row deletions in the CDC log. These values are mapped to the existing `RowDelete` and `PartitionDelete` variants as alternatives, so existing match arms continue to work without changes.

All `OperationType` variants now carry explicit discriminant values for clarity.

**New: TTL-expiration flag (`CDCRow::is_expiration`)**

CDCRow has a new public `is_expiration` bool field that is true when the operation was triggered by a TTL expiration (i.e. the raw operation code in the CDC log is negative). This lets consumers distinguish between explicit user deletions and automatic TTL-driven expirations.

Fixes: VECTOR-591