### PR TITLE
treewide: fix dependency lower bounds and manage them from the workspace root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,31 @@ members = [
     "scylla-cdc-replicator",
     "scylla-cdc-test-utils",
 ]
+
+[workspace.dependencies]
+scylla-cdc = { version = "0.6.3", path = "scylla-cdc" }
+scylla-cdc-test-utils = { path = "scylla-cdc-test-utils" }
+
+anyhow = "1.0.51"
+async-trait = "0.1.56"
+chrono = "0.4.32"
+clap = { version = "4.5.9", features = ["derive"] }
+futures = "0.3.17"
+futures-util = "0.3.19"
+hex = "0.4.3"
+itertools = "0.13.0"
+num_enum = "0.7.2"
+rand = "0.8.5"
+rstest = "0.26.1"
+scylla = "1.3.1"
+thiserror = "2.0.6"
+tokio = { version = "1.40", features = [
+    "rt",
+    "io-util",
+    "net",
+    "time",
+    "macros",
+    "sync",
+] }
+tracing = "0.1.36"
+uuid = { version = "1.0.0", features = ["v1"] }

--- a/scylla-cdc-printer/Cargo.toml
+++ b/scylla-cdc-printer/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scylla = "1.3.1"
-scylla-cdc = { version = "0.6.3", path = "../scylla-cdc" }
-tokio = { version = "1.40", features = ["full"] }
-chrono = "0.4.32"
-futures = "0.3.17"
-anyhow = "1.0.51"
-async-trait = "0.1.56"
-clap = { version = "4.5.9", features = ["derive"] }
+scylla = { workspace = true }
+scylla-cdc = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+chrono = { workspace = true }
+futures = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+clap = { workspace = true }
 
 [dev-dependencies]
-scylla-cdc-test-utils = { path = "../scylla-cdc-test-utils" }
+scylla-cdc-test-utils = { workspace = true }

--- a/scylla-cdc-printer/Cargo.toml
+++ b/scylla-cdc-printer/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2024"
 [dependencies]
 scylla = "1.3.1"
 scylla-cdc = { version = "0.6.3", path = "../scylla-cdc" }
-tokio = { version = "1.1.0", features = ["full"] }
-chrono = "0.4.19"
+tokio = { version = "1.40", features = ["full"] }
+chrono = "0.4.32"
 futures = "0.3.17"
 anyhow = "1.0.51"
-async-trait = "0.1.52"
+async-trait = "0.1.56"
 clap = { version = "4.5.9", features = ["derive"] }
 
 [dev-dependencies]

--- a/scylla-cdc-replicator/Cargo.toml
+++ b/scylla-cdc-replicator/Cargo.toml
@@ -8,16 +8,16 @@ edition = "2024"
 [dependencies]
 scylla = "1.3.1"
 scylla-cdc = { version = "0.6.3", path = "../scylla-cdc" }
-tokio = { version = "1.1.0", features = ["full"] }
-async-trait = "0.1.51"
-anyhow = "1.0.48"
+tokio = { version = "1.40", features = ["full"] }
+async-trait = "0.1.56"
+anyhow = "1.0.51"
 itertools = "0.13.0"
 uuid = { version = "1.0.0", features = ["v1"] }
 futures-util = "0.3.19"
-tracing = "0.1.34"
-chrono = "0.4.19"
+tracing = "0.1.36"
+chrono = "0.4.32"
 clap = { version = "4.5.9", features = ["derive"] }
-thiserror = "2.0"
+thiserror = "2.0.6"
 
 [dev-dependencies]
 scylla-cdc-test-utils = { path = "../scylla-cdc-test-utils" }

--- a/scylla-cdc-replicator/Cargo.toml
+++ b/scylla-cdc-replicator/Cargo.toml
@@ -6,19 +6,19 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scylla = "1.3.1"
-scylla-cdc = { version = "0.6.3", path = "../scylla-cdc" }
-tokio = { version = "1.40", features = ["full"] }
-async-trait = "0.1.56"
-anyhow = "1.0.51"
-itertools = "0.13.0"
-uuid = { version = "1.0.0", features = ["v1"] }
-futures-util = "0.3.19"
-tracing = "0.1.36"
-chrono = "0.4.32"
-clap = { version = "4.5.9", features = ["derive"] }
-thiserror = "2.0.6"
+scylla = { workspace = true }
+scylla-cdc = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+async-trait = { workspace = true }
+anyhow = { workspace = true }
+itertools = { workspace = true }
+uuid = { workspace = true }
+futures-util = { workspace = true }
+tracing = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-scylla-cdc-test-utils = { path = "../scylla-cdc-test-utils" }
-rstest = "0.26.1"
+scylla-cdc-test-utils = { workspace = true }
+rstest = { workspace = true }

--- a/scylla-cdc-test-utils/Cargo.toml
+++ b/scylla-cdc-test-utils/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.51"
-scylla = "1.3.1"
+anyhow = { workspace = true }
+scylla = { workspace = true }

--- a/scylla-cdc-test-utils/Cargo.toml
+++ b/scylla-cdc-test-utils/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.48"
+anyhow = "1.0.51"
 scylla = "1.3.1"

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -12,9 +12,9 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.48"
+anyhow = "1.0.51"
 scylla = "1.3.1"
-tokio = { version = "1.1.0", features = [
+tokio = { version = "1.40", features = [
     "rt",
     "io-util",
     "net",
@@ -25,8 +25,8 @@ tokio = { version = "1.1.0", features = [
 futures = "0.3.17"
 uuid = { version = "1.0.0", features = ["v1"] }
 num_enum = "0.7.2"
-async-trait = "0.1.51"
-tracing = "0.1.31"
+async-trait = "0.1.56"
+tracing = "0.1.36"
 itertools = "0.13.0"
 hex = "0.4.3"
 
@@ -35,7 +35,7 @@ hex = "0.4.3"
 rand = "0.8.5"
 scylla-cdc-test-utils = { path = "../scylla-cdc-test-utils" }
 # To compile one of the doc tests, we need rt-multi-thread feature.
-tokio = { version = "1.1.0", features = [
+tokio = { version = "1.40", features = [
     "rt",
     "io-util",
     "net",

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -12,36 +12,21 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.51"
-scylla = "1.3.1"
-tokio = { version = "1.40", features = [
-    "rt",
-    "io-util",
-    "net",
-    "time",
-    "macros",
-    "sync",
-] }
-futures = "0.3.17"
-uuid = { version = "1.0.0", features = ["v1"] }
-num_enum = "0.7.2"
-async-trait = "0.1.56"
-tracing = "0.1.36"
-itertools = "0.13.0"
-hex = "0.4.3"
+anyhow = { workspace = true }
+scylla = { workspace = true }
+tokio = { workspace = true }
+futures = { workspace = true }
+uuid = { workspace = true }
+num_enum = { workspace = true }
+async-trait = { workspace = true }
+tracing = { workspace = true }
+itertools = { workspace = true }
+hex = { workspace = true }
 
 [dev-dependencies]
-hex = "0.4.3"
-rand = "0.8.5"
-scylla-cdc-test-utils = { path = "../scylla-cdc-test-utils" }
+hex = { workspace = true }
+rand = { workspace = true }
+scylla-cdc-test-utils = { workspace = true }
 # To compile one of the doc tests, we need rt-multi-thread feature.
-tokio = { version = "1.40", features = [
-    "rt",
-    "io-util",
-    "net",
-    "time",
-    "macros",
-    "sync",
-    "rt-multi-thread",
-] }
-rstest = "0.26.1"
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+rstest = { workspace = true }


### PR DESCRIPTION
It was pointed out that `scylla-cdc` imports `tokio::task::JoinSet` while declaring `tokio = "1.1.0"`. `JoinSet` was not stabilised until 1.21, so the manifest advertised support for versions that cannot compile the crate. Auditing the rest of the manifests the same way turned up five more bounds below what the crates are actually built against.

| dep | was | now |
|---|---|---|
| tokio | 1.1.0 | 1.40 |
| chrono | 0.4.19 | 0.4.32 |
| tracing | 0.1.31 / 0.1.34 | 0.1.36 |
| async-trait | 0.1.51 / 0.1.52 | 0.1.56 |
| thiserror | 2.0 | 2.0.6 |
| anyhow | 1.0.48 | 1.0.51 |

The numbers come from `cargo +nightly update -Z direct-minimal-versions`, which pins every direct dependency to its declared minimum; each bound the resolver rejected was raised until the workspace resolved and built. All but `anyhow` land exactly on what `scylla` 1.3.1 requires — it is a non-optional dependency of all four crates, so its requirements are what really constrain the graph.

Worth flagging for tokio specifically: the fix is **1.40, not the 1.21** our own code needs. Because `scylla` 1.3.1 requires `tokio ^1.40`, no lockfile can resolve anything lower, so the reported compile failure is not reachable today. The declared bound was still wrong, and leaving a transitive dependency to enforce it is fragile.

The second commit then moves the versions into `[workspace.dependencies]`, since several were repeated across manifests and had to be kept in step by hand.

Fixes: VECTOR-776
